### PR TITLE
Use https in production

### DIFF
--- a/MaveSDK/MAVEConstants.m
+++ b/MaveSDK/MAVEConstants.m
@@ -21,7 +21,7 @@ NSString * const MAVESDKVersion = @"0.3.0";
     NSString * const MAVEShortLinkBaseURL = @"http://dev.appjoin.us/";
     #endif
 #else
-NSString * const MAVEAPIBaseURL = @"http://api.mave.io/";
+NSString * const MAVEAPIBaseURL = @"https://api.mave.io/";
 NSString * const MAVEShortLinkBaseURL = @"http://appjoin.us/";
 #endif
 


### PR DESCRIPTION
@dcosson I was looking at the nginx logs today and noticed all of the prod requests are still HTTP and getting redirected to HTTPS

```
83.220.239.197 - - [28/Jan/2015:14:54:34 +0000] "POST /v1.0/launch HTTP/1.1" 301 185 "-" "(iPhone; CPU iPhone OS 8_1_2 like Mac OS X)"
83.220.239.197 - - [28/Jan/2015:14:54:35 +0000] "POST /v1.0/launch HTTP/1.1" 201 0 "-" "(iPhone; CPU iPhone OS 8_1_2 like Mac OS X)"
```
