### PR TITLE
Fix waiting dots images in ios7

### DIFF
--- a/MaveSDK/Views/MAVEWaitingDotsImageView.m
+++ b/MaveSDK/Views/MAVEWaitingDotsImageView.m
@@ -27,11 +27,15 @@
 }
 
 - (void)setup {
-    self.animationImages = @[
-        [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots1" fromBundle:MAVEResourceBundleName],
-        [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots2" fromBundle:MAVEResourceBundleName],
-        [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots3" fromBundle:MAVEResourceBundleName],
-    ];
+    UIImage *image1 = [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots1" fromBundle:MAVEResourceBundleName];
+    UIImage *image2 = [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots2" fromBundle:MAVEResourceBundleName];
+    UIImage *image3 = [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots3" fromBundle:MAVEResourceBundleName];
+    if (!(image1 && image2 && image3)) {
+        MAVEErrorLog(@"Could not load the \"waiting dots\" image, image will be blank");
+        return;
+    }
+
+    self.animationImages = @[image1, image2, image3];
     self.animationDuration = 0.7;
     self.animationRepeatCount = 0;
     [self startAnimating ];

--- a/MaveSDK/Views/MAVEWaitingDotsImageView.m
+++ b/MaveSDK/Views/MAVEWaitingDotsImageView.m
@@ -27,9 +27,9 @@
 }
 
 - (void)setup {
-    UIImage *image1 = [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots1" fromBundle:MAVEResourceBundleName];
-    UIImage *image2 = [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots2" fromBundle:MAVEResourceBundleName];
-    UIImage *image3 = [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots3" fromBundle:MAVEResourceBundleName];
+    UIImage *image1 = [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots1.png" fromBundle:MAVEResourceBundleName];
+    UIImage *image2 = [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots2.png" fromBundle:MAVEResourceBundleName];
+    UIImage *image3 = [MAVEBuiltinUIElementUtils imageNamed:@"MAVEWaitingDots3.png" fromBundle:MAVEResourceBundleName];
     if (!(image1 && image2 && image3)) {
         MAVEErrorLog(@"Could not load the \"waiting dots\" image, image will be blank");
         return;


### PR DESCRIPTION
They weren't loading when used in external project without the ".png" extentions. Also add logging if somehow the images aren't loaded.