### PR TITLE
Add customData attribute to MAVEUserData 

### DIFF
--- a/MaveSDK/Controllers/MAVEInvitePageViewController.m
+++ b/MaveSDK/Controllers/MAVEInvitePageViewController.m
@@ -374,7 +374,7 @@
                                                 userId:mave.userData.userID
                               inviteLinkDestinationURL:mave.userData.inviteLinkDestinationURL
                                         wrapInviteLink:mave.userData.wrapInviteLink
-                                            customData:nil
+                                            customData:mave.userData.customData
                                        completionBlock:^(NSError *error, NSDictionary *responseData) {
         if (error != nil) {
             MAVEDebugLog(@"Invites failed to send, error: %@, response: %@",

--- a/MaveSDK/Models/MAVEUserData.h
+++ b/MaveSDK/Models/MAVEUserData.h
@@ -31,6 +31,15 @@
 // Defaults to YES, but you can set to NO if using your own deep linking tool
 @property (nonatomic, assign) BOOL wrapInviteLink;
 
+// customData is a freeform dictionary that you can use to
+// pass through any data you want to retrieve once the invited user opens
+// your app from this invite link. It will be available as the `customData`
+// property on the MAVEReferringData object. It is sent over our API as JSON
+// data so the object you pass in here must be JSON serializable - i.e.
+// NSJSONSerializiation `isValidJSONObject:` returns true.
+@property (nonatomic, strong) NSDictionary *customData;
+
+
 - (instancetype)initWithUserID:(NSString *)userID
                      firstName:(NSString *)firstName
                       lastName:(NSString *)lastName;

--- a/MaveSDKTests/Controllers/MAVEInvitePageViewControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVEInvitePageViewControllerTests.m
@@ -172,6 +172,40 @@
     OCMVerifyAll(mockAPIInterface);
 }
 
+- (void)testSendInvitesWithCustomData {
+    MaveSDK *mave = [MaveSDK sharedInstance];
+    mave.userData.inviteLinkDestinationURL = @"http://example.com/foo?referralCode=blah";
+    mave.userData.wrapInviteLink = NO;
+    MAVEInvitePageViewController *vc = [[MAVEInvitePageViewController alloc] init];
+    [vc loadView];
+    [vc viewDidLoad];
+    
+    // Setup content for invites
+    NSString *inviteMessage = @"This was the text typed in";
+    NSArray *invitePhones = @[@"18085551234"];
+    MAVEABPerson *p1 = [[MAVEABPerson alloc] init]; p1.recordID = 1; p1.firstName = @"Foo";
+    NSArray *inviteContacts = @[p1];
+    vc.ABTableViewController.selectedPhoneNumbers = [[NSMutableSet alloc] initWithArray: invitePhones];
+    vc.ABTableViewController.selectedPeople = [[NSMutableSet alloc] initWithArray:inviteContacts];
+    vc.bottomActionContainerView.inviteMessageView.textView.text = inviteMessage;
+    
+    NSDictionary *customData = @{@"foo": @"bar"};
+    mave.userData.customData = customData;
+    
+    // Create a mock http manager & stub the singleton object to use it
+    id mockAPIInterface = [OCMockObject partialMockForObject:[MaveSDK sharedInstance].APIInterface];
+    OCMExpect([mockAPIInterface sendInvitesWithRecipientPhoneNumbers:invitePhones
+                                             recipientContactRecords:inviteContacts
+                                                             message:inviteMessage
+                                                              userId:mave.userData.userID
+                                            inviteLinkDestinationURL:mave.userData.inviteLinkDestinationURL
+                                                      wrapInviteLink:NO
+                                                          customData:customData
+                                                     completionBlock:[OCMArg any]]);
+    [vc sendInvites];
+    OCMVerifyAll(mockAPIInterface);
+}
+
 - (void)testComposeClientGroupInvites {
     MAVEInvitePageViewController *vc = [[MAVEInvitePageViewController alloc] init];
     [vc loadView];

--- a/MaveSDKTests/Models/MAVEUserDataTests.m
+++ b/MaveSDKTests/Models/MAVEUserDataTests.m
@@ -44,6 +44,7 @@
     XCTAssertNil(ud.phone);
     XCTAssertFalse(ud.isSetAutomaticallyFromDevice);
     XCTAssertTrue(ud.wrapInviteLink);
+    XCTAssertNil(ud.customData);
 }
 
 - (void)testInitWithFullUserData {
@@ -55,6 +56,7 @@
     XCTAssertEqualObjects(ud.phone, @"ph");
     XCTAssertFalse(ud.isSetAutomaticallyFromDevice);
     XCTAssertTrue(ud.wrapInviteLink);
+    XCTAssertNil(ud.customData);
 }
 
 - (void)testInitWithDictionary {
@@ -72,6 +74,7 @@
     XCTAssertEqualObjects(ud.phone, @"ph");
     XCTAssertFalse(ud.isSetAutomaticallyFromDevice);
     XCTAssertTrue(ud.wrapInviteLink);
+    XCTAssertNil(ud.customData);
 }
 
 - (void)testInitAutomatically {
@@ -89,6 +92,7 @@
     XCTAssertNil(user.email);
     XCTAssertTrue(user.isSetAutomaticallyFromDevice);
     XCTAssertTrue(user.wrapInviteLink);
+    XCTAssertNil(user.customData);
 }
 
 - (void)testIsUserInfoOkToSendServerSideSMS {


### PR DESCRIPTION
customData NSDictionary will get passed through to the invites sent from the invite page view controller if set. (Doesn't have its own init method yet, it must be set on the userData after the init)