### PR TITLE
Dc fix push fallback client sms

### DIFF
--- a/MaveSDK/Controllers/MAVECustomSharePageViewController.m
+++ b/MaveSDK/Controllers/MAVECustomSharePageViewController.m
@@ -38,7 +38,8 @@
 }
 
 - (void)smsClientSideShare {
-    UIViewController *vc = [MAVESharer composeClientSMSInviteToRecipientPhones:nil completionBlock:^(MessageComposeResult result) {
+    UIViewController *vc = [MAVESharer composeClientSMSInviteToRecipientPhones:nil completionBlock:^(MFMessageComposeViewController *controller, MessageComposeResult result) {
+        [controller dismissViewControllerAnimated:YES completion:nil];
         if (result == MessageComposeResultSent) {
             [self dismissAfterShare];
         }

--- a/MaveSDK/Controllers/MAVEInvitePageChooser.h
+++ b/MaveSDK/Controllers/MAVEInvitePageChooser.h
@@ -63,6 +63,8 @@ extern NSString * const MAVEInvitePagePresentFormatPush;
 
 // Helper to replace whatever the active controller is with a new share page view controller
 - (void)replaceActiveViewControllerWithFallbackPage;
+- (void)dismissModalViewControllersAboveBottomIfAny;
+
 
 - (void)dismissOnSuccess:(NSUInteger)numberOfInvitesSent;
 - (void)dismissOnCancel;

--- a/MaveSDK/Controllers/MAVEInvitePageChooser.h
+++ b/MaveSDK/Controllers/MAVEInvitePageChooser.h
@@ -28,6 +28,7 @@ extern NSString * const MAVEInvitePagePresentFormatPush;
 @interface MAVEInvitePageChooser : NSObject
 
 @property (nonatomic, strong) UIViewController *activeViewController;
+@property (nonatomic, assign) BOOL needToUnwindReplacementModalViewController;
 - (UINavigationController *)activeNavigationController;
 @property (nonatomic, copy) NSString *navigationPresentedFormat;
 @property (nonatomic, copy) MAVEInvitePageDismissBlock navigationCancelBlock;

--- a/MaveSDK/Controllers/MAVEInvitePageChooser.m
+++ b/MaveSDK/Controllers/MAVEInvitePageChooser.m
@@ -119,7 +119,8 @@ NSString * const MAVEInvitePagePresentFormatPush = @"push";
         MAVEErrorLog(@"Tried to push the client sms form which doesn't work, need to display the view controller modally to show the client sms compose invite page.");
         return nil;
     }
-    return [MAVESharer composeClientSMSInviteToRecipientPhones:nil completionBlock:^(MessageComposeResult result) {
+    return [MAVESharer composeClientSMSInviteToRecipientPhones:nil completionBlock:^(MFMessageComposeViewController *controller,
+                                                                                     MessageComposeResult result) {
         switch (result) {
             case MessageComposeResultCancelled:
                 [self dismissOnCancel];

--- a/MaveSDK/Controllers/MAVEInvitePageChooser.m
+++ b/MaveSDK/Controllers/MAVEInvitePageChooser.m
@@ -130,7 +130,6 @@ NSString * const MAVEInvitePagePresentFormatPush = @"push";
             case MessageComposeResultSent:
                 [self dismissOnSuccess:1];
         }
-        [self dismissOnCancel];
     }];
 }
 
@@ -248,12 +247,35 @@ NSString * const MAVEInvitePagePresentFormatPush = @"push";
         MAVEErrorLog(@"Error, got nil view controller from fallback page type");
         self.activeViewController = [[MAVECustomSharePageViewController alloc] init];
     }
-    [self setupNavigationBarForActiveViewController];
-    [navigationController pushViewController:self.activeViewController animated:NO];
+
+    // We prefer to push the replacement controller onto the navigation stack so that we can still dismiss
+    // our bottom level view controller normally. But if the replacement controller is a navigation controller
+    // (e.g. client sms dialog) we can't do that so we have to present it on top of the modal
+    if ([self.activeViewController isKindOfClass:[UINavigationController class]]) {
+        [navigationController presentViewController:self.activeViewController animated:YES completion:nil];
+        self.needToUnwindReplacementModalViewController = YES;
+    } else {
+        [self setupNavigationBarForActiveViewController];
+        [navigationController pushViewController:self.activeViewController animated:NO];
+    }
 }
 
+- (void)dismissModalViewControllersAboveBottomIfAny {
+    // If we presented a second view controller over our view controller as a modal,
+    // remove it so that we're back to just one view controller displayed that can
+    // be dismissed by the application code.
+    //
+    // This gets triggered for client side sms compose screen fallback
+    if (self.needToUnwindReplacementModalViewController) {
+        UIViewController *bottomActiveViewController = [self.activeViewController presentingViewController];
+        [self.activeViewController dismissViewControllerAnimated:NO completion:nil];
+        self.activeViewController = bottomActiveViewController;
+        self.needToUnwindReplacementModalViewController = NO;
+    }
+}
 
 - (void)dismissOnSuccess:(NSUInteger)numberOfInvitesSent {
+    [self dismissModalViewControllersAboveBottomIfAny];
     [self.activeViewController.view endEditing:YES];
     if ([self.navigationPresentedFormat isEqualToString:MAVEInvitePagePresentFormatModal]) {
         if (self.navigationCancelBlock) {
@@ -269,6 +291,7 @@ NSString * const MAVEInvitePagePresentFormatPush = @"push";
 }
 
 - (void)dismissOnCancel {
+    [self dismissModalViewControllersAboveBottomIfAny];
     [self.activeViewController.view endEditing:YES];
     if (self.navigationCancelBlock) {
         self.navigationCancelBlock(self.activeViewController, 0);

--- a/MaveSDK/Controllers/MAVEInvitePageViewController.m
+++ b/MaveSDK/Controllers/MAVEInvitePageViewController.m
@@ -415,7 +415,7 @@
 
 - (void)composeClientGroupSMSInvites {
     NSArray *recipientPhones = [self.ABTableViewController.selectedPhoneNumbers allObjects];
-    UIViewController *vc = [MAVESharer composeClientSMSInviteToRecipientPhones:recipientPhones completionBlock:^(MessageComposeResult result) {
+    UIViewController *vc = [MAVESharer composeClientSMSInviteToRecipientPhones:recipientPhones completionBlock:^(MFMessageComposeViewController *controller, MessageComposeResult result) {
 
     }];
     if (!vc) {

--- a/MaveSDK/Controllers/MAVEInvitePageViewController.m
+++ b/MaveSDK/Controllers/MAVEInvitePageViewController.m
@@ -55,6 +55,7 @@
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
+    self.ABTableViewController.tableView.delegate = nil;
     [self.view endEditing:YES];
 }
 

--- a/MaveSDK/Controllers/MAVESharer.h
+++ b/MaveSDK/Controllers/MAVESharer.h
@@ -19,7 +19,7 @@ extern NSString * const MAVESharePageShareTypeClipboard;
 @interface MAVESharer : NSObject <MFMessageComposeViewControllerDelegate>
 
 @property (nonatomic, strong) MAVESharer *retainedSelf;
-@property (nonatomic, strong) void(^completionBlockClientSMS)(MessageComposeResult composeResult);
+@property (nonatomic, strong) void(^completionBlockClientSMS)(MFMessageComposeViewController *controller, MessageComposeResult composeResult);
 
 - (instancetype)initAndRetainSelf;
 - (void)releaseSelf;
@@ -28,7 +28,8 @@ extern NSString * const MAVESharePageShareTypeClipboard;
 // Methods to compose and share, they return UIViewControllers that need to be presented to display the compose views
 //
 + (MFMessageComposeViewController *)composeClientSMSInviteToRecipientPhones:(NSArray *)recipientPhones
-                                              completionBlock:(void(^)(MessageComposeResult result))completionBlock;
+                                              completionBlock:(void(^)(MFMessageComposeViewController *controller,
+                                                                       MessageComposeResult composeResult))completionBlock;
 //
 // Helpers
 //

--- a/MaveSDK/Controllers/MAVESharer.m
+++ b/MaveSDK/Controllers/MAVESharer.m
@@ -33,7 +33,7 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
     self.retainedSelf = nil;
 }
 
-+ (MFMessageComposeViewController *)composeClientSMSInviteToRecipientPhones:(NSArray *)recipientPhones completionBlock:(void (^)(MessageComposeResult))completionBlock {
++ (MFMessageComposeViewController *)composeClientSMSInviteToRecipientPhones:(NSArray *)recipientPhones completionBlock:(void (^)(MFMessageComposeViewController *controller, MessageComposeResult composeResult))completionBlock {
     if (![MFMessageComposeViewController canSendText]) {
         MAVEErrorLog(@"Tried to do compose client sms but canSendText is false");
         return nil;
@@ -69,9 +69,8 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
             break;
         }
     }
-    [controller dismissViewControllerAnimated:YES completion:nil];
     if (self.completionBlockClientSMS) {
-        self.completionBlockClientSMS(result);
+        self.completionBlockClientSMS(controller, result);
     }
     [self releaseSelf];
 }

--- a/MaveSDKTests/Controllers/MAVECustomSharePageViewControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVECustomSharePageViewControllerTests.m
@@ -98,8 +98,8 @@
     id mock = OCMPartialMock(vc);
     id sharerMock = OCMClassMock([MAVESharer class]);
     OCMExpect([sharerMock composeClientSMSInviteToRecipientPhones:nil completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
-        void (^completionBlock)(MessageComposeResult result) = obj;
-        completionBlock(MessageComposeResultSent);
+        void (^completionBlock)(MFMessageComposeViewController *controller, MessageComposeResult result) = obj;
+        completionBlock(nil, MessageComposeResultSent);
         return YES;
     }]]);
     OCMExpect([mock presentViewController:[OCMArg any] animated:YES completion:nil]);
@@ -117,8 +117,8 @@
     id mock = OCMPartialMock(vc);
     id sharerMock = OCMClassMock([MAVESharer class]);
     OCMExpect([sharerMock composeClientSMSInviteToRecipientPhones:nil completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
-        void (^completionBlock)(MessageComposeResult result) = obj;
-        completionBlock(MessageComposeResultCancelled);
+        void (^completionBlock)(MFMessageComposeViewController *controller, MessageComposeResult result) = obj;
+        completionBlock(nil, MessageComposeResultCancelled);
         return YES;
     }]]);
     OCMExpect([mock presentViewController:[OCMArg any] animated:YES completion:nil]);
@@ -136,8 +136,8 @@
     id mock = OCMPartialMock(vc);
     id sharerMock = OCMClassMock([MAVESharer class]);
     OCMExpect([sharerMock composeClientSMSInviteToRecipientPhones:nil completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
-        void (^completionBlock)(MessageComposeResult result) = obj;
-        completionBlock(MessageComposeResultFailed);
+        void (^completionBlock)(MFMessageComposeViewController *controller, MessageComposeResult result) = obj;
+        completionBlock(nil, MessageComposeResultFailed);
         return YES;
     }]]);
     OCMExpect([mock presentViewController:[OCMArg any] animated:YES completion:nil]);

--- a/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
+++ b/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
@@ -234,8 +234,8 @@
     UIViewController *fakeReturnedVC = [[UIViewController alloc] init];
     id sharerMock = OCMClassMock([MAVESharer class]);
     OCMExpect([sharerMock composeClientSMSInviteToRecipientPhones:nil completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
-        void (^completionBlock)(MessageComposeResult result) = obj;
-        completionBlock(MessageComposeResultSent);
+        void (^completionBlock)(MFMessageComposeViewController *controller, MessageComposeResult result) = obj;
+        completionBlock(nil, MessageComposeResultSent);
         return YES;
     }]]).andReturn(fakeReturnedVC);
 
@@ -254,8 +254,8 @@
     UIViewController *fakeReturnedVC = [[UIViewController alloc] init];
     id sharerMock = OCMClassMock([MAVESharer class]);
     OCMExpect([sharerMock composeClientSMSInviteToRecipientPhones:nil completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
-        void (^completionBlock)(MessageComposeResult result) = obj;
-        completionBlock(MessageComposeResultCancelled);
+        void (^completionBlock)(MFMessageComposeViewController *controller, MessageComposeResult result) = obj;
+        completionBlock(nil, MessageComposeResultCancelled);
         return YES;
     }]]).andReturn(fakeReturnedVC);
 

--- a/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
+++ b/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
@@ -492,7 +492,7 @@
 
 - (void)testDismissModalViewControllersAboveBottomNoNeedToUnwind {
     MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
-    chooser.needToUnwindReplacementModalViewController = NO;
+    // need to unwind will be false
     chooser.activeViewController = [[UIViewController alloc] init];
     id vcMock = OCMPartialMock(chooser.activeViewController);
     [[vcMock reject] dismissViewControllerAnimated:NO completion:nil];

--- a/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
+++ b/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
@@ -490,12 +490,42 @@
     XCTAssertEqual(forwardButton.action, @selector(dismissOnForward));
 }
 
+- (void)testDismissModalViewControllersAboveBottomNoNeedToUnwind {
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    chooser.needToUnwindReplacementModalViewController = NO;
+    chooser.activeViewController = [[UIViewController alloc] init];
+    id vcMock = OCMPartialMock(chooser.activeViewController);
+    [[vcMock reject] dismissViewControllerAnimated:NO completion:nil];
+
+    [chooser dismissModalViewControllersAboveBottomIfAny];
+
+    OCMVerifyAll(vcMock);
+}
+
+- (void)testDismissModalViewControllersAboveBottom {
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    chooser.needToUnwindReplacementModalViewController = YES;
+    chooser.activeViewController = [[UIViewController alloc] init];
+    id vcMock = OCMPartialMock(chooser.activeViewController);
+    UIViewController *fakePresentingVC = [[UIViewController alloc] init];
+    OCMExpect([vcMock presentingViewController]).andReturn(fakePresentingVC);
+    OCMExpect([vcMock dismissViewControllerAnimated:NO completion:nil]);
+
+    [chooser dismissModalViewControllersAboveBottomIfAny];
+
+    OCMVerifyAll(vcMock);
+    XCTAssertEqualObjects(chooser.activeViewController, fakePresentingVC);
+    XCTAssertFalse(chooser.needToUnwindReplacementModalViewController);
+}
+
+
 ///
 /// Forward and back/cancel actions
 ///
 - (void)testDismissOnSuccessWhenModal {
     // When modal, dismiss on success calls the cancel block
     MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
     chooser.navigationPresentedFormat = MAVEInvitePagePresentFormatModal;
     chooser.activeViewController = [[UIViewController alloc] init];
 
@@ -509,10 +539,13 @@
         numInvites = numberOfInvitesSent;
     };
 
+    OCMExpect([chooserMock dismissModalViewControllersAboveBottomIfAny]);
+
     [chooser dismissOnSuccess:102];
 
     XCTAssertEqualObjects(calledWithVC, chooser.activeViewController);
     XCTAssertEqual(numInvites, 102);
+    OCMVerifyAll(chooserMock);
 }
 
 - (void)testDismissOnSuccessWhenPush {
@@ -540,19 +573,23 @@
 -(void)testDismissOnCancelNoBlock {
     MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
     chooser.activeViewController = [[UIViewController alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
     id viewMock = OCMClassMock([UIView class]);
     id vcMock = OCMPartialMock(chooser.activeViewController);
     OCMStub([vcMock view]).andReturn(viewMock);
     OCMExpect([viewMock endEditing:YES]);
+    OCMExpect([chooserMock dismissModalViewControllersAboveBottomIfAny]);
 
     // with no back block just ends editing for the view
     [chooser dismissOnCancel];
     OCMVerifyAll(viewMock);
+    OCMVerifyAll(chooserMock);
 }
 
 - (void)testDismissOnCancelWithBlock {
     MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
     chooser.activeViewController = [[UIViewController alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
     id viewMock = OCMClassMock([UIView class]);
     id vcMock = OCMPartialMock(chooser.activeViewController);
     OCMStub([vcMock view]).andReturn(viewMock);
@@ -565,9 +602,12 @@
         numInvites = numberOfInvitesSent;
     };
 
+    OCMExpect([chooserMock dismissModalViewControllersAboveBottomIfAny]);
+
     [chooser dismissOnCancel];
 
     OCMVerifyAll(viewMock);
+    OCMVerifyAll(chooserMock);
     XCTAssertEqualObjects(calledWithVC, chooser.activeViewController);
     XCTAssertEqual(numInvites, 0);
 }

--- a/MaveSDKTests/Controllers/MAVEInvitePageViewControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVEInvitePageViewControllerTests.m
@@ -221,8 +221,8 @@
     UIViewController *fakeMessageComposeVC = OCMClassMock([MFMessageComposeViewController class]);
     id maveSharerMock = OCMClassMock([MAVESharer class]);
     OCMExpect([maveSharerMock composeClientSMSInviteToRecipientPhones:invitePhones completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
-        void (^completionBlock)(MessageComposeResult result) = obj;
-        completionBlock(MessageComposeResultSent);
+        void (^completionBlock)(MFMessageComposeViewController *controller, MessageComposeResult result) = obj;
+        completionBlock(nil, MessageComposeResultSent);
         return YES;
     }]]).andReturn(fakeMessageComposeVC);
 

--- a/MaveSDKTests/Controllers/MAVESharerTests.m
+++ b/MaveSDKTests/Controllers/MAVESharerTests.m
@@ -66,7 +66,7 @@
     // sms recipient
     OCMExpect([messageComposeVCMock setRecipients:recipientPhones]);
 
-    void (^myCompletionBlock)(MessageComposeResult result) = ^void(MessageComposeResult result) {};
+    void (^myCompletionBlock)(MFMessageComposeViewController *controller, MessageComposeResult result) = ^void(MFMessageComposeViewController *controller, MessageComposeResult result) {};
     UIViewController *vc = [MAVESharer composeClientSMSInviteToRecipientPhones:recipientPhones completionBlock:myCompletionBlock];
 
     XCTAssertNotNil(vc);
@@ -92,7 +92,7 @@
 - (void)testComposeClientSMSCompletionBlockSuccess {
     MAVESharer *sharer = [[MAVESharer alloc] initAndRetainSelf];
     __block MessageComposeResult returnedResult;
-    sharer.completionBlockClientSMS = ^void(MessageComposeResult result) {
+    sharer.completionBlockClientSMS = ^void(MFMessageComposeViewController *controller, MessageComposeResult result) {
         returnedResult = result;
     };
     NSString *fakeToken = @"foo12398akj";
@@ -103,7 +103,8 @@
     OCMExpect([apiInterfaceMock trackShareWithShareType:MAVESharePageShareTypeClientSMS shareToken:fakeToken audience:nil]);
 
     id messageComposeVCMock = OCMClassMock([MFMessageComposeViewController class]);
-    OCMExpect([messageComposeVCMock dismissViewControllerAnimated:YES completion:nil]);
+    // should not get dismissed, the caller is responsible for dismissing controller in the block
+    [[messageComposeVCMock reject] dismissViewControllerAnimated:YES completion:nil];
     [sharer messageComposeViewController:messageComposeVCMock didFinishWithResult:MessageComposeResultSent];
 
     XCTAssertEqual(returnedResult, MessageComposeResultSent);
@@ -116,7 +117,7 @@
 - (void)testComposeClientSMSCancelled {
     MAVESharer *sharer = [[MAVESharer alloc] initAndRetainSelf];
     __block MessageComposeResult returnedResult;
-    sharer.completionBlockClientSMS = ^void(MessageComposeResult result) {
+    sharer.completionBlockClientSMS = ^void(MFMessageComposeViewController *controller, MessageComposeResult result) {
         returnedResult = result;
     };
 
@@ -124,7 +125,7 @@
     [[apiInterfaceMock reject] trackShareWithShareType:MAVESharePageShareTypeClientSMS shareToken:[OCMArg any] audience:[OCMArg any]];
 
     id messageComposeVCMock = OCMClassMock([MFMessageComposeViewController class]);
-    OCMExpect([messageComposeVCMock dismissViewControllerAnimated:YES completion:nil]);
+    [[messageComposeVCMock reject] dismissViewControllerAnimated:YES completion:nil];
     [sharer messageComposeViewController:messageComposeVCMock didFinishWithResult:MessageComposeResultCancelled];
 
     XCTAssertEqual(returnedResult, MessageComposeResultCancelled);


### PR DESCRIPTION
Fix the client side sms compose page fallback in the case where it's being presented over the existing invite page after the user denies contacts permission.