### PR TITLE
Allow unwrapped links to be passed to client SMS view controller

### DIFF
--- a/MaveSDK/Controllers/MAVESharer.m
+++ b/MaveSDK/Controllers/MAVESharer.m
@@ -46,8 +46,7 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
     NSString *message;
     if ( maveUser.inviteLinkDestinationURL && !maveUser.wrapInviteLink ) {
         // If the inviteLinkDestinationURL is set, and the link should NOT be wrapped, pass the raw inviteLinkDestinationURL to the SMS VC
-        message = ownInstance.remoteConfiguration.clientSMS.text;
-        message = [[message stringByAppendingString:@" "] stringByAppendingString:maveUser.inviteLinkDestinationURL];
+        message = [[ownInstance.remoteConfiguration.clientSMS.text stringByAppendingString:@" "] stringByAppendingString:maveUser.inviteLinkDestinationURL];
     } else {
         message = [ownInstance shareCopyFromCopy:ownInstance.remoteConfiguration.clientSMS.text andLinkWithSubRouteLetter:@"s"];
     }

--- a/MaveSDK/Controllers/MAVESharer.m
+++ b/MaveSDK/Controllers/MAVESharer.m
@@ -42,7 +42,15 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
     ownInstance.completionBlockClientSMS = completionBlock;
 
     MFMessageComposeViewController *composeVC = [MAVESharerViewControllerBuilder MFMessageComposeViewController];
-    NSString *message = [ownInstance shareCopyFromCopy:ownInstance.remoteConfiguration.clientSMS.text andLinkWithSubRouteLetter:@"s"];
+    MAVEUserData *maveUser = [MaveSDK sharedInstance].userData;
+    NSString *message;
+    if ( maveUser.inviteLinkDestinationURL && !maveUser.wrapInviteLink ) {
+        // If the inviteLinkDestinationURL is set, and the link should NOT be wrapped, pass the raw inviteLinkDestinationURL to the SMS VC
+        message = ownInstance.remoteConfiguration.clientSMS.text;
+        message = [[message stringByAppendingString:@" "] stringByAppendingString:maveUser.inviteLinkDestinationURL];
+    } else {
+        message = [ownInstance shareCopyFromCopy:ownInstance.remoteConfiguration.clientSMS.text andLinkWithSubRouteLetter:@"s"];
+    }
 
     composeVC.messageComposeDelegate = ownInstance;
     composeVC.body = message;


### PR DESCRIPTION
If `userData.inviteLinkDestinationURL` is set, and `userData.wrapInviteLink` is `NO`, append the raw invite link destination to the client SMS view controller rather than the share token link