### PR TITLE
Dc templating

### DIFF
--- a/MaveSDK.podspec
+++ b/MaveSDK.podspec
@@ -37,4 +37,5 @@ Pod::Spec.new do |s|
 
   # 3rd party cocoapod dependencies
   s.dependency 'libPhoneNumber-iOS', '~> 0.8.3'
+  s.dependency 'CCTemplate', '0.2.0'
 end

--- a/MaveSDK.xcodeproj/project.pbxproj
+++ b/MaveSDK.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		0C775E301A9FB6F30028D687 /* MAVEReferringDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C775E2F1A9FB6F30028D687 /* MAVEReferringDataTests.m */; };
 		0C96015C1A6DC57F004DBA93 /* MAVESearchBarTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C96015B1A6DC57F004DBA93 /* MAVESearchBarTests.m */; };
 		0C96015E1A71444B004DBA93 /* MAVEInviteTableHeaderViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C96015D1A71444B004DBA93 /* MAVEInviteTableHeaderViewTests.m */; };
+		0CA08EA71AC20DC2009BB2CE /* MAVETemplatingUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CA08EA61AC20DC2009BB2CE /* MAVETemplatingUtils.m */; };
+		0CA08EA91AC20DD0009BB2CE /* MAVETemplatingUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CA08EA81AC20DD0009BB2CE /* MAVETemplatingUtilsTests.m */; };
 		0CC62BC81A8EA6E800D2AF14 /* MAVERange64Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CC62BC71A8EA6E800D2AF14 /* MAVERange64Tests.m */; };
 		0CC6463619F9C6190006A1D0 /* MAVEABTableViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CC6463519F9C6190006A1D0 /* MAVEABTableViewControllerTests.m */; };
 		0CC7B3C01A96AC62004455A7 /* MAVEWaitingDotsImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CC7B3BF1A96AC62004455A7 /* MAVEWaitingDotsImageView.m */; };
@@ -303,6 +305,9 @@
 		0C775E2F1A9FB6F30028D687 /* MAVEReferringDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVEReferringDataTests.m; sourceTree = "<group>"; };
 		0C96015B1A6DC57F004DBA93 /* MAVESearchBarTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVESearchBarTests.m; sourceTree = "<group>"; };
 		0C96015D1A71444B004DBA93 /* MAVEInviteTableHeaderViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVEInviteTableHeaderViewTests.m; sourceTree = "<group>"; };
+		0CA08EA51AC20DC2009BB2CE /* MAVETemplatingUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MAVETemplatingUtils.h; sourceTree = "<group>"; };
+		0CA08EA61AC20DC2009BB2CE /* MAVETemplatingUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVETemplatingUtils.m; sourceTree = "<group>"; };
+		0CA08EA81AC20DD0009BB2CE /* MAVETemplatingUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVETemplatingUtilsTests.m; sourceTree = "<group>"; };
 		0CC62BC71A8EA6E800D2AF14 /* MAVERange64Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVERange64Tests.m; sourceTree = "<group>"; };
 		0CC6463519F9C6190006A1D0 /* MAVEABTableViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVEABTableViewControllerTests.m; sourceTree = "<group>"; };
 		0CC7B3BE1A96AC62004455A7 /* MAVEWaitingDotsImageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MAVEWaitingDotsImageView.h; sourceTree = "<group>"; };
@@ -484,6 +489,8 @@
 				0C1A8FD91A644D7900518D9A /* MAVENameParsingUtils.m */,
 				0C6D92AB1A72BE4A00B65B82 /* MAVECompressionUtils.h */,
 				0C6D92AC1A72BE4A00B65B82 /* MAVECompressionUtils.m */,
+				0CA08EA51AC20DC2009BB2CE /* MAVETemplatingUtils.h */,
+				0CA08EA61AC20DC2009BB2CE /* MAVETemplatingUtils.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -497,6 +504,7 @@
 				0C1F1A1B1A532FC900B2D482 /* MAVEClientPropertyUtilsTests.m */,
 				0C1A8FDB1A644E5C00518D9A /* MAVENameParsingUtilsTests.m */,
 				0C6D92AE1A72E3E000B65B82 /* MAVECompressionUtilsTests.m */,
+				0CA08EA81AC20DD0009BB2CE /* MAVETemplatingUtilsTests.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1173,6 +1181,7 @@
 				0C1E6ACB1AA9267A002EBD2E /* MAVEInvitePageBottomActionSendButtonOnlyView.m in Sources */,
 				C0F4C8EE19F162B80003D209 /* MAVEInviteSendingProgressView.m in Sources */,
 				C029280419E82D0F006AEE43 /* MAVEABUtils.m in Sources */,
+				0CA08EA71AC20DC2009BB2CE /* MAVETemplatingUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1205,6 +1214,7 @@
 				0CCC92C01A60090D008CB888 /* MAVECustomSharePageViewControllerTests.m in Sources */,
 				C022641619EC41010087FF37 /* MAVEABPersonTests.m in Sources */,
 				0C29BC571A5DE74300C27DA5 /* MAVEShareTokenTests.m in Sources */,
+				0CA08EA91AC20DD0009BB2CE /* MAVETemplatingUtilsTests.m in Sources */,
 				0C58FE051A66D977007F8F12 /* MAVERemoteConfigurationServerSMSTests.m in Sources */,
 				0C1F1A171A51F4F300B2D482 /* MAVERemoteConfigurationContactsPrePromptTests.m in Sources */,
 				C029282419E83189006AEE43 /* MaveSDKTests.m in Sources */,

--- a/MaveSDK/MaveSDK.m
+++ b/MaveSDK/MaveSDK.m
@@ -138,7 +138,7 @@ static dispatch_once_t sharedInstanceonceToken;
     if (_defaultSMSMessageText) {
         return _defaultSMSMessageText;
     } else {
-        return self.remoteConfiguration.serverSMS.text;
+        return self.remoteConfiguration.serverSMS.smsCopy;
     }
 }
 

--- a/MaveSDK/MaveSDK.m
+++ b/MaveSDK/MaveSDK.m
@@ -138,7 +138,7 @@ static dispatch_once_t sharedInstanceonceToken;
     if (_defaultSMSMessageText) {
         return _defaultSMSMessageText;
     } else {
-        return self.remoteConfiguration.serverSMS.smsCopy;
+        return self.remoteConfiguration.serverSMS.text;
     }
 }
 

--- a/MaveSDK/Models/MAVEUserData.h
+++ b/MaveSDK/Models/MAVEUserData.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#define MAVEUserDataKeyUserID @"user_id"
+extern NSString * const MAVEUserDataKeyUserID;
 
 @interface MAVEUserData : NSObject
 
@@ -17,6 +17,7 @@
 @property (nonatomic, copy) NSString *lastName;
 @property (nonatomic, copy) NSString *email;
 @property (nonatomic, copy) NSString *phone;
+@property (nonatomic, copy) NSString *promoCode;
 
 // Internal flag, for use with anonymous users
 @property (nonatomic, assign) BOOL isSetAutomaticallyFromDevice;

--- a/MaveSDK/Models/MAVEUserData.m
+++ b/MaveSDK/Models/MAVEUserData.m
@@ -11,10 +11,12 @@
 #import "MAVENameParsingUtils.h"
 #import "MAVEClientPropertyUtils.h"
 
-#define MAVEUserDataKeyFirstName @"first_name"
-#define MAVEUserDataKeyLastName @"last_name"
-#define MAVEUserDataKeyEmail @"email"
-#define MAVEUserDataKeyPhone @"phone"
+NSString * const MAVEUserDataKeyUserID = @"user_id";
+NSString * const MAVEUserDataKeyFirstName = @"first_name";
+NSString * const MAVEUserDataKeyLastName = @"last_name";
+NSString * const MAVEUserDataKeyEmail = @"email";
+NSString * const MAVEUserDataKeyPhone = @"phone";
+NSString * const MAVEUserDataKeyPromoCode = @"promo_code";
 
 @implementation MAVEUserData
 
@@ -58,6 +60,7 @@
         self.lastName = [dict objectForKey:MAVEUserDataKeyLastName];
         self.email = [dict objectForKey:MAVEUserDataKeyEmail];
         self.phone = [dict objectForKey:MAVEUserDataKeyPhone];
+        self.promoCode = [dict objectForKey:MAVEUserDataKeyPromoCode];
     }
     return self;
 }
@@ -80,11 +83,12 @@
 
 - (NSDictionary *)toDictionary {
     NSMutableDictionary *output = [[NSMutableDictionary alloc] init];
-    if (self.userID) [output setObject:self.userID forKey:MAVEUserDataKeyUserID];
-    if (self.firstName) [output setObject:self.firstName forKey:MAVEUserDataKeyFirstName];
-    if (self.lastName) [output setObject:self.lastName forKey:MAVEUserDataKeyLastName];
-    if (self.email) [output setObject:self.email forKey:MAVEUserDataKeyEmail];
-    if (self.phone) [output setObject:self.phone forKey:MAVEUserDataKeyPhone];
+    if (self.userID) [output setValue:self.userID forKey:MAVEUserDataKeyUserID];
+    if (self.firstName) [output setValue:self.firstName forKey:MAVEUserDataKeyFirstName];
+    if (self.lastName) [output setValue:self.lastName forKey:MAVEUserDataKeyLastName];
+    if (self.email) [output setValue:self.email forKey:MAVEUserDataKeyEmail];
+    if (self.phone) [output setValue:self.phone forKey:MAVEUserDataKeyPhone];
+    if (self.promoCode) [output setValue:self.promoCode forKey:MAVEUserDataKeyPromoCode];
     return (NSDictionary *)output;
 }
 

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientEmail.h
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientEmail.h
@@ -12,8 +12,10 @@
 @interface MAVERemoteConfigurationClientEmail : NSObject<MAVEDictionaryInitializable>
 
 @property (nonatomic, copy) NSString *templateID;
-@property (nonatomic, copy) NSString *subject;
-@property (nonatomic, copy) NSString *body;
+@property (nonatomic, copy) NSString *subjectTemplate;
+- (NSString *)subject;
+@property (nonatomic, copy) NSString *bodyTemplate;
+- (NSString *)body;
 
 + (NSDictionary *)defaultJSONData;
 

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientEmail.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientEmail.m
@@ -8,11 +8,12 @@
 
 #import "MAVERemoteConfigurationClientEmail.h"
 #import "MAVEClientPropertyUtils.h"
+#import "MAVETemplatingUtils.h"
 
 NSString * const MAVERemoteConfigKeyClientEmailTemplate = @"template";
 NSString * const MAVERemoteConfigKeyClientEmailTemplateID = @"template_id";
-NSString * const MAVERemoteConfigKeyClientEmailSubject = @"subject";
-NSString * const MAVERemoteConfigKeyClientEmailBody = @"body";
+NSString * const MAVERemoteConfigKeyClientEmailSubject = @"subject_template";
+NSString * const MAVERemoteConfigKeyClientEmailBody = @"body_template";
 
 @implementation MAVERemoteConfigurationClientEmail
 
@@ -26,17 +27,25 @@ NSString * const MAVERemoteConfigKeyClientEmailBody = @"body";
         }
         NSString *subject = [template objectForKey:MAVERemoteConfigKeyClientEmailSubject];
         if (![subject isEqual:[NSNull null]]) {
-            self.subject = subject;
+            self.subjectTemplate = subject;
         }
         NSString *body = [template objectForKey:MAVERemoteConfigKeyClientEmailBody];
         if (![body isEqual:[NSNull null]]) {
-            self.body = body;
+            self.bodyTemplate = body;
         }
-        if (!self.subject || !self.body) {
+        if (!self.subjectTemplate || !self.bodyTemplate) {
             return nil;
         }
     }
     return self;
+}
+
+- (NSString *)subject {
+    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.subjectTemplate];
+}
+
+- (NSString *)body {
+    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.bodyTemplate];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientSMS.h
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientSMS.h
@@ -12,7 +12,8 @@
 @interface MAVERemoteConfigurationClientSMS : NSObject<MAVEDictionaryInitializable>
 
 @property (nonatomic, copy) NSString *templateID;
-@property (nonatomic, copy) NSString *text;
+@property (nonatomic, copy) NSString *textTemplate;
+- (NSString *)text;
 
 + (NSDictionary *)defaultJSONData;
 

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientSMS.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientSMS.m
@@ -8,10 +8,11 @@
 
 #import "MAVERemoteConfigurationClientSMS.h"
 #import "MAVEClientPropertyUtils.h"
+#import "MAVETemplatingUtils.h"
 
 NSString * const MAVERemoteConfigKeyClientSMSTemplate = @"template";
 NSString * const MAVERemoteConfigKeyClientSMSTemplateID = @"template_id";
-NSString * const MAVERemoteConfigKeyClientSMSCopy = @"copy";
+NSString * const MAVERemoteConfigKeyClientSMSCopyTemplate = @"copy_template";
 
 
 @implementation MAVERemoteConfigurationClientSMS
@@ -24,16 +25,20 @@ NSString * const MAVERemoteConfigKeyClientSMSCopy = @"copy";
         if (![templateID isEqual:[NSNull null]]) {
             self.templateID = templateID;
         }
-        NSString *text = [template objectForKey:MAVERemoteConfigKeyClientSMSCopy];
+        NSString *text = [template objectForKey:MAVERemoteConfigKeyClientSMSCopyTemplate];
         if (![text isEqual:[NSNull null]]) {
-            self.text = text;
+            self.textTemplate = text;
         }
-        if (!self.text) {
+        if (!self.textTemplate) {
             return nil;
         }
         
     }
     return self;
+}
+
+- (NSString *)text {
+    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.textTemplate];
 }
 
 + (NSDictionary *)defaultJSONData {
@@ -42,7 +47,7 @@ NSString * const MAVERemoteConfigKeyClientSMSCopy = @"copy";
     return @{
         MAVERemoteConfigKeyClientSMSTemplate: @{
             MAVERemoteConfigKeyClientSMSTemplateID: @"0",
-            MAVERemoteConfigKeyClientSMSCopy: text,
+            MAVERemoteConfigKeyClientSMSCopyTemplate: text,
         },
 
     };

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClipboardShare.h
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClipboardShare.h
@@ -12,7 +12,8 @@
 @interface MAVERemoteConfigurationClipboardShare : NSObject<MAVEDictionaryInitializable>
 
 @property (nonatomic, copy) NSString *templateID;
-@property (nonatomic, copy) NSString *text;
+@property (nonatomic, copy) NSString *textTemplate;
+- (NSString *)text;
 
 + (NSDictionary *)defaultJSONData;
 

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClipboardShare.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClipboardShare.m
@@ -8,10 +8,11 @@
 
 #import "MAVERemoteConfigurationClipboardShare.h"
 #import "MAVEClientPropertyUtils.h"
+#import "MAVETemplatingUtils.h"
 
 NSString * const MAVERemoteConfigKeyClipboardShareTemplate = @"template";
 NSString * const MAVERemoteConfigKeyClipboardShareTemplateID = @"template_id";
-NSString * const MAVERemoteConfigKeyClipboardShareCopy = @"copy";
+NSString * const MAVERemoteConfigKeyClipboardShareCopy = @"copy_template";
 
 @implementation MAVERemoteConfigurationClipboardShare
 
@@ -25,14 +26,18 @@ NSString * const MAVERemoteConfigKeyClipboardShareCopy = @"copy";
         }
         NSString *text = [template objectForKey:MAVERemoteConfigKeyClipboardShareCopy];
         if (![text isEqual:[NSNull null]]) {
-            self.text = text;
+            self.textTemplate = text;
         }
-        if (!self.text) {
+        if (!self.textTemplate) {
             return nil;
         }
 
     }
     return self;
+}
+
+- (NSString *)text {
+    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.textTemplate];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePage.h
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePage.h
@@ -18,7 +18,8 @@ typedef NS_ENUM(NSInteger, MAVESMSInviteSendMethod) {
 
 @property (nonatomic) BOOL enabled;
 @property (nonatomic, copy) NSString *templateID;
-@property (nonatomic, copy) NSString *explanationCopy;
+@property (nonatomic, copy) NSString *explanationCopyTemplate;
+- (NSString *)explanationCopy;
 @property (nonatomic) BOOL suggestedInvitesEnabled;
 @property (nonatomic, assign) MAVESMSInviteSendMethod smsInviteSendMethod;
 

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePage.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePage.m
@@ -8,11 +8,12 @@
 
 #import "MAVERemoteConfigurationContactsInvitePage.h"
 #import "MAVEClientPropertyUtils.h"
+#import "MAVETemplatingUtils.h"
 
 NSString * const MAVERemoteConfigKeyContactsInvitePageEnabled = @"enabled";
 NSString * const MAVERemoteConfigKeyContactsInvitePageTemplate = @"template";
 NSString * const MAVERemoteConfigKeyContactsInvitePageTemplateID = @"template_id";
-NSString * const MAVERemoteConfigKeyContactsInvitePageExplanationCopy = @"explanation_copy";
+NSString * const MAVERemoteConfigKeyContactsInvitePageExplanationCopy = @"explanation_copy_template";
 NSString * const MAVERemoteConfigKeyContactsInvitePageSuggestedInvitesEnabled = @"suggested_invites_enabled";
 NSString * const MAVERemoteConfigKeyContactsInvitePageSMSSendMethod = @"sms_invite_send_method";
 NSString * const MAVERemoteConfigKeyContactsInvitePageSMSSendMethodServerSide = @"server_side";
@@ -39,9 +40,9 @@ NSString * const MAVERemoteConfigKeyContactsInvitePageSMSSendMethodClientSideGro
                 self.templateID = templateIDVal;
             }
 
-            NSString *explanationCopyVal = [template objectForKey:MAVERemoteConfigKeyContactsInvitePageExplanationCopy];
-            if (explanationCopyVal != (id)[NSNull null]) {
-                self.explanationCopy = explanationCopyVal;
+            NSString *explanationCopyTemplate = [template objectForKey:MAVERemoteConfigKeyContactsInvitePageExplanationCopy];
+            if (explanationCopyTemplate != (id)[NSNull null]) {
+                self.explanationCopyTemplate = explanationCopyTemplate;
             }
 
             id suggestedInvitesVal = [template objectForKey:MAVERemoteConfigKeyContactsInvitePageSuggestedInvitesEnabled];
@@ -57,6 +58,10 @@ NSString * const MAVERemoteConfigKeyContactsInvitePageSMSSendMethodClientSideGro
         }
     }
     return self;
+}
+
+- (NSString *)explanationCopy {
+    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.explanationCopyTemplate];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationCustomSharePage.h
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationCustomSharePage.h
@@ -13,7 +13,8 @@
 
 @property (nonatomic) BOOL enabled;
 @property (nonatomic, copy) NSString *templateID;
-@property (nonatomic, copy) NSString *explanationCopy;
+@property (nonatomic, copy) NSString *explanationCopyTemplate;
+- (NSString *)explanationCopy;
 
 + (NSDictionary *)defaultJSONData;
 

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationCustomSharePage.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationCustomSharePage.m
@@ -39,7 +39,7 @@ const NSString *MAVERemoteConfigKeyCustomSharePageExplanationCopy = @"explanatio
             if (![explanationCopyTemplate isEqual:[NSNull null]]) {
                 self.explanationCopyTemplate = explanationCopyTemplate;
             }
-            if (!self.explanationCopy) {
+            if (!self.explanationCopyTemplate) {
                 return nil;
             }
         }

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationCustomSharePage.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationCustomSharePage.m
@@ -8,11 +8,12 @@
 
 #import "MAVERemoteConfigurationCustomSharePage.h"
 #import "MAVEClientPropertyUtils.h"
+#import "MAVETemplatingUtils.h"
 
 const NSString *MAVERemoteConfigKeyCustomSharePageEnabled = @"enabled";
 const NSString *MAVERemoteConfigKeyCustomSharePageTemplate = @"template";
 const NSString *MAVERemoteConfigKeyCustomSharePageTemplateID = @"template_id";
-const NSString *MAVERemoteConfigKeyCustomSharePageExplanationCopy = @"explanation_copy";
+const NSString *MAVERemoteConfigKeyCustomSharePageExplanationCopy = @"explanation_copy_template";
 
 @implementation MAVERemoteConfigurationCustomSharePage
 
@@ -34,9 +35,9 @@ const NSString *MAVERemoteConfigKeyCustomSharePageExplanationCopy = @"explanatio
                 self.templateID = templateID;
             }
 
-            NSString *explanationCopy = [template objectForKey:MAVERemoteConfigKeyCustomSharePageExplanationCopy];
-            if (![explanationCopy isEqual:[NSNull null]]) {
-                self.explanationCopy = explanationCopy;
+            NSString *explanationCopyTemplate = [template objectForKey:MAVERemoteConfigKeyCustomSharePageExplanationCopy];
+            if (![explanationCopyTemplate isEqual:[NSNull null]]) {
+                self.explanationCopyTemplate = explanationCopyTemplate;
             }
             if (!self.explanationCopy) {
                 return nil;
@@ -44,6 +45,10 @@ const NSString *MAVERemoteConfigKeyCustomSharePageExplanationCopy = @"explanatio
         }
     }
     return self;
+}
+
+- (NSString *)explanationCopy {
+    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.explanationCopyTemplate];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationFacebookShare.h
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationFacebookShare.h
@@ -12,7 +12,8 @@
 @interface MAVERemoteConfigurationFacebookShare : NSObject<MAVEDictionaryInitializable>
 
 @property (nonatomic, copy) NSString *templateID;
-@property (nonatomic, copy) NSString *text;
+@property (nonatomic, copy) NSString *textTemplate;
+- (NSString *)text;
 
 + (NSDictionary *)defaultJSONData;
 

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationFacebookShare.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationFacebookShare.m
@@ -8,10 +8,11 @@
 
 #import "MAVERemoteConfigurationFacebookShare.h"
 #import "MAVEClientPropertyUtils.h"
+#import "MAVETemplatingUtils.h"
 
 NSString * const MAVERemoteConfigKeyFacebookShareTemplate = @"template";
 NSString * const MAVERemoteConfigKeyFacebookShareTemplateID = @"template_id";
-NSString * const MAVERemoteConfigKeyFacebookShareCopy = @"initial_text";
+NSString * const MAVERemoteConfigKeyFacebookShareCopy = @"initial_text_template";
 
 @implementation MAVERemoteConfigurationFacebookShare
 
@@ -24,14 +25,18 @@ NSString * const MAVERemoteConfigKeyFacebookShareCopy = @"initial_text";
         }
         NSString *text = [template objectForKey:MAVERemoteConfigKeyFacebookShareCopy];
         if (![text isEqual:[NSNull null]]) {
-            self.text = text;
+            self.textTemplate = text;
         }
-        if (!self.text) {
+        if (!self.textTemplate) {
             return nil;
         }
 
     }
     return self;
+}
+
+- (NSString *)text {
+    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.textTemplate];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMS.h
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMS.h
@@ -13,7 +13,7 @@
 
 @property (nonatomic, copy) NSString *templateID;
 @property (nonatomic, copy) NSString *textTemplate;
-- (NSString *)smsCopy;
+- (NSString *)text;
 
 + (NSDictionary *)defaultJSONData;
 

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMS.h
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMS.h
@@ -12,7 +12,8 @@
 @interface MAVERemoteConfigurationServerSMS : NSObject<MAVEDictionaryInitializable>
 
 @property (nonatomic, copy) NSString *templateID;
-@property (nonatomic, copy) NSString *text;
+@property (nonatomic, copy) NSString *textTemplate;
+- (NSString *)smsCopy;
 
 + (NSDictionary *)defaultJSONData;
 

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMS.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMS.m
@@ -8,10 +8,11 @@
 
 #import "MAVERemoteConfigurationServerSMS.h"
 #import "MAVEClientPropertyUtils.h"
+#import "MAVETemplatingUtils.h"
 
 NSString * const MAVERemoteConfigKeyServerSMSTemplate = @"template";
 NSString * const MAVERemoteConfigKeyServerSMSTemplateID = @"template_id";
-NSString * const MAVERemoteConfigKeyServerSMSCopy = @"copy";
+NSString * const MAVERemoteConfigKeyServerSMSCopy = @"copy_template";
 
 
 @implementation MAVERemoteConfigurationServerSMS
@@ -26,14 +27,19 @@ NSString * const MAVERemoteConfigKeyServerSMSCopy = @"copy";
         }
         NSString *text = [template objectForKey:MAVERemoteConfigKeyServerSMSCopy];
         if (![text isEqual:[NSNull null]]) {
-            self.text = text;
+            self.textTemplate = text;
         }
-        if (!self.text) {
+        if (!self.textTemplate) {
             return nil;
         }
 
     }
     return self;
+}
+
+// Returns the sms copy with template values filled in
+- (NSString *)smsCopy {
+    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.textTemplate];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMS.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMS.m
@@ -38,7 +38,7 @@ NSString * const MAVERemoteConfigKeyServerSMSCopy = @"copy_template";
 }
 
 // Returns the sms copy with template values filled in
-- (NSString *)smsCopy {
+- (NSString *)text {
     return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.textTemplate];
 }
 

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationTwitterShare.h
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationTwitterShare.h
@@ -12,7 +12,8 @@
 @interface MAVERemoteConfigurationTwitterShare : NSObject<MAVEDictionaryInitializable>
 
 @property (nonatomic, copy) NSString *templateID;
-@property (nonatomic, copy) NSString *text;
+@property (nonatomic, copy) NSString *textTemplate;
+- (NSString *)text;
 
 + (NSDictionary *)defaultJSONData;
 

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationTwitterShare.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationTwitterShare.m
@@ -8,10 +8,11 @@
 
 #import "MAVERemoteConfigurationTwitterShare.h"
 #import "MAVEClientPropertyUtils.h"
+#import "MAVETemplatingUtils.h"
 
 NSString * const MAVERemoteConfigKeyTwitterShareTemplate = @"template";
 NSString * const MAVERemoteConfigKeyTwitterShareTemplateID = @"template_id";
-NSString * const MAVERemoteConfigKeyTwitterShareCopy = @"copy";
+NSString * const MAVERemoteConfigKeyTwitterShareCopy = @"copy_template";
 
 @implementation MAVERemoteConfigurationTwitterShare
 
@@ -25,14 +26,18 @@ NSString * const MAVERemoteConfigKeyTwitterShareCopy = @"copy";
         }
         NSString *text = [template objectForKey:MAVERemoteConfigKeyTwitterShareCopy];
         if (![text isEqual:[NSNull null]]) {
-            self.text = text;
+            self.textTemplate = text;
         }
-        if (!self.text) {
+        if (!self.textTemplate) {
             return nil;
         }
 
     }
     return self;
+}
+
+- (NSString *)text {
+    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.textTemplate];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Utils/MAVETemplatingUtils.h
+++ b/MaveSDK/Utils/MAVETemplatingUtils.h
@@ -1,0 +1,22 @@
+//
+//  MAVETemplatingUtils.h
+//  MaveSDK
+//
+//  Created by Danny Cosson on 3/24/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "MAVEUserData.h"
+
+@interface MAVETemplatingUtils : NSObject
+
+// Helper method to interpolate the template string using the current context.
+// Available fields in template are user.* and customData.*
++ (NSString *)interpolateTemplateString:(NSString *)templateString
+                               withUser:(MAVEUserData *)user
+                             customData:(NSDictionary *)customData;
+
++ (NSString *)interpolateWithSingletonDataTemplateString:(NSString *)templateString;
+
+@end

--- a/MaveSDK/Utils/MAVETemplatingUtils.h
+++ b/MaveSDK/Utils/MAVETemplatingUtils.h
@@ -11,6 +11,10 @@
 
 @interface MAVETemplatingUtils : NSObject
 
+// Convert any id to a string value if possible, or return nil if not possible.
+// Will convert NSNumber and NSNull successfully, not arbitrary objects.
++ (NSString *)convertValueToString:(id)value;
+
 // Helper method to interpolate the template string using the current context.
 // Available fields in template are user.* and customData.*
 + (NSString *)interpolateTemplateString:(NSString *)templateString

--- a/MaveSDK/Utils/MAVETemplatingUtils.m
+++ b/MaveSDK/Utils/MAVETemplatingUtils.m
@@ -1,0 +1,41 @@
+//
+//  MAVETemplatingUtils.m
+//  MaveSDK
+//
+//  Created by Danny Cosson on 3/24/15.
+//
+//
+
+#import "MAVETemplatingUtils.h"
+#import "MaveSDK.h"
+#import "CCTemplate.h"
+
+@implementation MAVETemplatingUtils
+
++ (NSString *)interpolateTemplateString:(NSString *)templateString withUser:(MAVEUserData *)user customData:(NSDictionary *)customData {
+
+    NSMutableDictionary *interpolationDict = [[NSMutableDictionary alloc] init];
+    [interpolationDict setValue:user.userID forKey:@"user.userID"];
+    [interpolationDict setValue:user.firstName forKey:@"user.firstName"];
+    [interpolationDict setValue:user.lastName forKey:@"user.lastName"];
+    [interpolationDict setValue:user.fullName forKey:@"user.fullName"];
+
+    NSString *namespacedKey, *key, *value;
+    for (key in customData) {
+        value = [customData valueForKey:key];
+        namespacedKey = [@"customData." stringByAppendingString:key];
+        [interpolationDict setValue:value forKey:namespacedKey];
+    }
+
+    NSString *output = [templateString templateFromDict:[NSDictionary dictionaryWithDictionary:interpolationDict]];
+    return output;
+}
+
++ (NSString *)interpolateWithSingletonDataTemplateString:(NSString *)templateString {
+    MAVEUserData *user = [MaveSDK sharedInstance].userData;
+    NSDictionary *customData = user.customData;
+    return [self interpolateTemplateString:templateString withUser:user customData:customData];
+}
+
+
+@end

--- a/MaveSDK/Utils/MAVETemplatingUtils.m
+++ b/MaveSDK/Utils/MAVETemplatingUtils.m
@@ -21,6 +21,7 @@
     [interpolationDict setValue:user.firstName forKey:@"user.firstName"];
     [interpolationDict setValue:user.lastName forKey:@"user.lastName"];
     [interpolationDict setValue:user.fullName forKey:@"user.fullName"];
+    [interpolationDict setValue:user.promoCode forKey:@"user.promoCode"];
 
     NSString *namespacedKey, *key, *stringValue;
     for (key in customData) {

--- a/MaveSDK/Utils/MAVETemplatingUtils.m
+++ b/MaveSDK/Utils/MAVETemplatingUtils.m
@@ -15,20 +15,41 @@
 + (NSString *)interpolateTemplateString:(NSString *)templateString withUser:(MAVEUserData *)user customData:(NSDictionary *)customData {
 
     NSMutableDictionary *interpolationDict = [[NSMutableDictionary alloc] init];
+
+    // All these user fields are NSStrings
     [interpolationDict setValue:user.userID forKey:@"user.userID"];
     [interpolationDict setValue:user.firstName forKey:@"user.firstName"];
     [interpolationDict setValue:user.lastName forKey:@"user.lastName"];
     [interpolationDict setValue:user.fullName forKey:@"user.fullName"];
 
-    NSString *namespacedKey, *key, *value;
+    NSString *namespacedKey, *key, *stringValue;
     for (key in customData) {
-        value = [customData valueForKey:key];
+        if (![key isKindOfClass:[NSString class]]) {
+            continue;
+        }
+        stringValue = [self convertValueToString:[customData objectForKey:key]];
+        if (!stringValue) {
+            continue;
+        }
         namespacedKey = [@"customData." stringByAppendingString:key];
-        [interpolationDict setValue:value forKey:namespacedKey];
+        [interpolationDict setValue:stringValue forKey:namespacedKey];
     }
 
     NSString *output = [templateString templateFromDict:[NSDictionary dictionaryWithDictionary:interpolationDict]];
     return output;
+}
+
++ (NSString *)convertValueToString:(id)value {
+    if ([value isKindOfClass:[NSString class]]) {
+        return value;
+    }
+    if ([value isKindOfClass:[NSNumber class]]) {
+        return [((NSNumber *)value) stringValue];
+    }
+    if (value == (id)[NSNull null]) {
+        return @"<null>";
+    }
+    return nil;
 }
 
 + (NSString *)interpolateWithSingletonDataTemplateString:(NSString *)templateString {

--- a/MaveSDKTests/MaveSDKTests.m
+++ b/MaveSDKTests/MaveSDKTests.m
@@ -172,7 +172,7 @@
     // can be set in remote config
     MAVERemoteConfiguration *remoteConfig = [[MAVERemoteConfiguration alloc] init];
     remoteConfig.contactsInvitePage = [[MAVERemoteConfigurationContactsInvitePage alloc] init];
-    remoteConfig.contactsInvitePage.explanationCopy = @"foo";
+    remoteConfig.contactsInvitePage.explanationCopyTemplate = @"foo";
     id maveMock = OCMPartialMock(mave);
     OCMStub([maveMock remoteConfiguration]).andReturn(remoteConfig);
 

--- a/MaveSDKTests/MaveSDKTests.m
+++ b/MaveSDKTests/MaveSDKTests.m
@@ -52,7 +52,7 @@
     MaveSDK *mave = [MaveSDK sharedInstance];
     XCTAssertEqualObjects(mave.appId, @"foo123");
     XCTAssertNotNil(mave.displayOptions);
-    XCTAssertEqualObjects(mave.defaultSMSMessageText, mave.remoteConfiguration.serverSMS.text);
+    XCTAssertEqualObjects(mave.defaultSMSMessageText, mave.remoteConfiguration.serverSMS.smsCopy);
     XCTAssertNotNil(mave.appDeviceID);
     XCTAssertNotNil(mave.remoteConfigurationBuilder);
     XCTAssertNotNil(mave.shareTokenBuilder);
@@ -152,7 +152,7 @@
     // can be set in remote config
     MAVERemoteConfiguration *remoteConfig = [[MAVERemoteConfiguration alloc] init];
     remoteConfig.serverSMS = [[MAVERemoteConfigurationServerSMS alloc] init];
-    remoteConfig.serverSMS.text = @"foo";
+    remoteConfig.serverSMS.textTemplate = @"foo";
     id maveMock = OCMPartialMock(mave);
     OCMStub([maveMock remoteConfiguration]).andReturn(remoteConfig);
 

--- a/MaveSDKTests/MaveSDKTests.m
+++ b/MaveSDKTests/MaveSDKTests.m
@@ -52,7 +52,7 @@
     MaveSDK *mave = [MaveSDK sharedInstance];
     XCTAssertEqualObjects(mave.appId, @"foo123");
     XCTAssertNotNil(mave.displayOptions);
-    XCTAssertEqualObjects(mave.defaultSMSMessageText, mave.remoteConfiguration.serverSMS.smsCopy);
+    XCTAssertEqualObjects(mave.defaultSMSMessageText, mave.remoteConfiguration.serverSMS.text);
     XCTAssertNotNil(mave.appDeviceID);
     XCTAssertNotNil(mave.remoteConfigurationBuilder);
     XCTAssertNotNil(mave.shareTokenBuilder);

--- a/MaveSDKTests/Models/MAVEUserDataTests.m
+++ b/MaveSDKTests/Models/MAVEUserDataTests.m
@@ -45,6 +45,7 @@
     XCTAssertFalse(ud.isSetAutomaticallyFromDevice);
     XCTAssertTrue(ud.wrapInviteLink);
     XCTAssertNil(ud.customData);
+    XCTAssertNil(ud.promoCode);
 }
 
 - (void)testInitWithFullUserData {
@@ -57,6 +58,7 @@
     XCTAssertFalse(ud.isSetAutomaticallyFromDevice);
     XCTAssertTrue(ud.wrapInviteLink);
     XCTAssertNil(ud.customData);
+    XCTAssertNil(ud.promoCode);
 }
 
 - (void)testInitWithDictionary {
@@ -66,12 +68,14 @@
             @"last_name": @"la",
             @"email": @"em",
             @"phone": @"ph",
+            @"promo_code": @"pc",
     }];
     XCTAssertEqualObjects(ud.userID, @"id1");
     XCTAssertEqualObjects(ud.firstName, @"fi");
     XCTAssertEqualObjects(ud.lastName, @"la");
     XCTAssertEqualObjects(ud.email, @"em");
     XCTAssertEqualObjects(ud.phone, @"ph");
+    XCTAssertEqualObjects(ud.promoCode, @"pc");
     XCTAssertFalse(ud.isSetAutomaticallyFromDevice);
     XCTAssertTrue(ud.wrapInviteLink);
     XCTAssertNil(ud.customData);
@@ -90,6 +94,7 @@
     XCTAssertEqualObjects(user.lastName, @"Cosson");
     XCTAssertNil(user.phone);
     XCTAssertNil(user.email);
+    XCTAssertNil(user.promoCode);
     XCTAssertTrue(user.isSetAutomaticallyFromDevice);
     XCTAssertTrue(user.wrapInviteLink);
     XCTAssertNil(user.customData);
@@ -129,11 +134,13 @@
 
 - (void)testToDictionaryNoNils {
     MAVEUserData *ud = [[MAVEUserData alloc] initWithUserID:@"id1" firstName:@"fi" lastName:@"la" email:@"em" phone:@"ph"];
+    ud.promoCode = @"pc";
     NSDictionary *expected = @{@"user_id": @"id1",
                                @"first_name": @"fi",
                                @"last_name": @"la",
                                @"email": @"em",
-                               @"phone": @"ph"};
+                               @"phone": @"ph",
+                               @"promo_code": @"pc"};
     XCTAssertEqualObjects([ud toDictionary], expected);
 }
 

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationClientSMSTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationClientSMSTests.m
@@ -8,7 +8,9 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
 #import "MAVERemoteConfigurationClientSMS.h"
+#import "MAVETemplatingUtils.h"
 
 @interface MAVERemoteConfigurationClientSMSTests : XCTestCase
 
@@ -32,7 +34,7 @@
     XCTAssertNotNil(template);
 
     XCTAssertEqualObjects([template objectForKey:@"template_id"], @"0");
-    XCTAssertEqualObjects([template objectForKey:@"copy"],
+    XCTAssertEqualObjects([template objectForKey:@"copy_template"],
                           @"Join me on DemoApp!");
 }
 
@@ -40,7 +42,7 @@
     MAVERemoteConfigurationClientSMS *obj = [[MAVERemoteConfigurationClientSMS alloc] initWithDictionary:[MAVERemoteConfigurationClientSMS defaultJSONData]];
 
     XCTAssertEqualObjects(obj.templateID, @"0");
-    XCTAssertEqualObjects(obj.text, @"Join me on DemoApp!");
+    XCTAssertEqualObjects(obj.textTemplate, @"Join me on DemoApp!");
 }
 
 - (void)testInitFailsIfTemplateMalformed {
@@ -48,7 +50,7 @@
     NSDictionary *data = @{@"template": @{@"template_id": @"foo"}};
     MAVERemoteConfigurationClientSMS *obj = [[MAVERemoteConfigurationClientSMS alloc] initWithDictionary:data];
 
-    data = @{@"template": @{@"template_id": @"foo", @"copy": [NSNull null]}};
+    data = @{@"template": @{@"template_id": @"foo", @"copy_template": [NSNull null]}};
     obj = [[MAVERemoteConfigurationClientSMS alloc] initWithDictionary:data];
 
     XCTAssertNil(obj);
@@ -59,13 +61,27 @@
                            @"enabled": @YES,
                            @"template": @{
                                    @"template_id": [NSNull null],
-                                   @"copy": @"foo",
+                                   @"copy_template": @"foo",
                                    }
                            };
     MAVERemoteConfigurationClientSMS *obj = [[MAVERemoteConfigurationClientSMS alloc] initWithDictionary:dict];
     // should be nil, not nsnull
     XCTAssertNotNil(obj);
     XCTAssertNil(obj.templateID);
+}
+
+- (void)testTextFillsInTemplate {
+    id templatingUtilsMock = OCMClassMock([MAVETemplatingUtils class]);
+    NSString *templateString = @"{{ customData.foo }}";
+    OCMExpect([templatingUtilsMock interpolateWithSingletonDataTemplateString:templateString]).andReturn(@"bar1");
+
+    MAVERemoteConfigurationClientSMS *clientSMSConfig = [[MAVERemoteConfigurationClientSMS alloc] init];
+    clientSMSConfig.textTemplate = templateString;
+
+    NSString *output = [clientSMSConfig text];
+
+    OCMVerifyAll(templatingUtilsMock);
+    XCTAssertEqualObjects(output, @"bar1");
 }
 
 @end

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePageTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePageTests.m
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "MaveSDK.h"
 #import "MAVERemoteConfigurationContactsInvitePage.h"
 
 @interface MAVERemoteConfigurationContactsInvitePageTests : XCTestCase
@@ -33,7 +35,7 @@
     NSDictionary *template = [defaults objectForKey:@"template"];
     XCTAssertEqualObjects([template objectForKey:@"template_id"], @"0");
 
-    XCTAssertNil([template objectForKey:@"explanation_copy"]);
+    XCTAssertNil([template objectForKey:@"explanation_copy_template"]);
     XCTAssertFalse([[template objectForKey:@"suggested_invites_enabled"] boolValue]);
     XCTAssertEqualObjects([template objectForKey:@"sms_invite_send_method"], @"server_side");
 }
@@ -60,12 +62,24 @@
     XCTAssertNil(obj);
 }
 
+- (void)testExplanationCopyInterpolatesTemplate {
+    id maveMock = OCMPartialMock([MaveSDK sharedInstance]);
+    MAVEUserData *user = [[MAVEUserData alloc] init];
+    user.promoCode = @"1234foo";
+    OCMStub([maveMock userData]).andReturn(user);
+
+    MAVERemoteConfigurationContactsInvitePage *obj = [[MAVERemoteConfigurationContactsInvitePage alloc] init];
+    obj.explanationCopyTemplate = @"Hey use my code {{ user.promoCode }}!";
+
+    XCTAssertEqualObjects(obj.explanationCopy, @"Hey use my code 1234foo!");
+}
+
 - (void)testInitSucceedsIfTemplateValid {
     NSDictionary *dict = @{
         @"enabled": @YES,
         @"template": @{
             @"template_id": @"1",
-            @"explanation_copy": @"some copy",
+            @"explanation_copy_template": @"some copy",
             @"suggested_invites_enabled": @YES,
         }
     };
@@ -93,7 +107,7 @@
                            @"enabled": @YES,
                            @"template": @{
                                    @"template_id": [NSNull null],
-                                   @"explanation_copy": [NSNull null],
+                                   @"explanation_copy_template": [NSNull null],
                                    @"suggested_invites_enabled": [NSNull null],
                             }
                            };

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationCustomSharePageTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationCustomSharePageTests.m
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "MaveSDK.h"
 #import "MAVERemoteConfigurationCustomSharePage.h"
 
 @interface MAVERemoteConfigurationCustomSharePageTests : XCTestCase
@@ -35,7 +37,7 @@
 
     // The actual app name here comes from the bundle name, this test always runs in
     // the context of the demo app
-    XCTAssertEqualObjects([template objectForKey:@"explanation_copy"],
+    XCTAssertEqualObjects([template objectForKey:@"explanation_copy_template"],
                           @"Share DemoApp with friends");
 }
 
@@ -45,6 +47,18 @@
     XCTAssertEqualObjects(obj.templateID, @"0");
     XCTAssertEqualObjects(obj.explanationCopy,
                           @"Share DemoApp with friends");
+}
+
+- (void)testExplanationCopyInterpolatesTemplate {
+    id maveMock = OCMPartialMock([MaveSDK sharedInstance]);
+    MAVEUserData *user = [[MAVEUserData alloc] init];
+    user.promoCode = @"1234foo";
+    OCMStub([maveMock userData]).andReturn(user);
+
+    MAVERemoteConfigurationCustomSharePage *obj = [[MAVERemoteConfigurationCustomSharePage alloc] init];
+    obj.explanationCopyTemplate = @"Hey use my code {{ user.promoCode }}!";
+
+    XCTAssertEqualObjects(obj.explanationCopy, @"Hey use my code 1234foo!");
 }
 
 - (void)testInitFailsIfEnabledKeyIsMissing {
@@ -71,7 +85,7 @@
     // or if required fields are nsnull
     dict = @{ @"enabled": @YES, @"template": @{
                     @"template_id": @"foo",
-                    @"explanation_copy": [NSNull null],
+                    @"explanation_copy_template": [NSNull null],
             }
     };
     obj = [[MAVERemoteConfigurationCustomSharePage alloc] initWithDictionary:dict];
@@ -82,7 +96,7 @@
     NSDictionary *dict = @{
                            @"enabled": @YES,
                            @"template": @{
-                                   @"explanation_copy": @"",
+                                   @"explanation_copy_template": @"",
                                    }
                            };
 
@@ -96,7 +110,7 @@
     NSDictionary *dict = @{
                            @"enabled": @YES,
                            @"template": @{
-                                   @"explanation_copy": @"foo",
+                                   @"explanation_copy_template": @"foo",
                                    @"template_id": [NSNull null],
                                    }
                            };

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMSTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMSTests.m
@@ -72,7 +72,7 @@
     XCTAssertNil(obj.templateID);
 }
 
-- (void)testSMSCopy {
+- (void)testTextFillsInTemplate {
     id templatingUtilsMock = OCMClassMock([MAVETemplatingUtils class]);
     NSString *templateString = @"{{ customData.foo }}";
     OCMExpect([templatingUtilsMock interpolateWithSingletonDataTemplateString:templateString]).andReturn(@"bar1");

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMSTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMSTests.m
@@ -80,7 +80,7 @@
     MAVERemoteConfigurationServerSMS *serverSMSConfig = [[MAVERemoteConfigurationServerSMS alloc] init];
     serverSMSConfig.textTemplate = templateString;
 
-    NSString *output = [serverSMSConfig smsCopy];
+    NSString *output = [serverSMSConfig text];
 
     OCMVerifyAll(templatingUtilsMock);
     XCTAssertEqualObjects(output, @"bar1");

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationTwitterShareTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationTwitterShareTests.m
@@ -8,7 +8,9 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
 #import "MAVERemoteConfigurationTwitterShare.h"
+#import "MAVETemplatingUtils.h"
 
 @interface MAVERemoteConfigurationTwitterShareTests : XCTestCase
 
@@ -32,14 +34,14 @@
     XCTAssertNotNil(template);
 
     XCTAssertEqualObjects([template objectForKey:@"template_id"], @"0");
-    XCTAssertEqualObjects([template objectForKey:@"copy"], @"I love DemoApp. Try it out");
+    XCTAssertEqualObjects([template objectForKey:@"copy_template"], @"I love DemoApp. Try it out");
 }
 
 - (void)testInitFromDefaultData {
     MAVERemoteConfigurationTwitterShare *obj = [[MAVERemoteConfigurationTwitterShare alloc] initWithDictionary:[MAVERemoteConfigurationTwitterShare defaultJSONData]];
 
     XCTAssertEqualObjects(obj.templateID, @"0");
-    XCTAssertEqualObjects(obj.text, @"I love DemoApp. Try it out");
+    XCTAssertEqualObjects(obj.textTemplate, @"I love DemoApp. Try it out");
 }
 
 - (void)testInitFailsIfTemplateMalformed {
@@ -48,7 +50,7 @@
     MAVERemoteConfigurationTwitterShare *obj = [[MAVERemoteConfigurationTwitterShare alloc] initWithDictionary:data];
     XCTAssertNil(obj);
 
-    data = @{@"template": @{@"template_id": @"foo", @"copy": [NSNull null]}};
+    data = @{@"template": @{@"template_id": @"foo", @"copy_template": [NSNull null]}};
     obj = [[MAVERemoteConfigurationTwitterShare alloc] initWithDictionary:data];
     XCTAssertNil(obj);
 }
@@ -58,13 +60,27 @@
                            @"enabled": @YES,
                            @"template": @{
                                    @"template_id": [NSNull null],
-                                   @"copy": @"foo",
+                                   @"copy_template": @"foo",
                                    }
                            };
     MAVERemoteConfigurationTwitterShare *obj = [[MAVERemoteConfigurationTwitterShare alloc] initWithDictionary:dict];
     // should be nil, not nsnull
     XCTAssertNotNil(obj);
     XCTAssertNil(obj.templateID);
+}
+
+- (void)testTextFillsInTemplate {
+    id templatingUtilsMock = OCMClassMock([MAVETemplatingUtils class]);
+    NSString *templateString = @"{{ customData.foo }}";
+    OCMExpect([templatingUtilsMock interpolateWithSingletonDataTemplateString:templateString]).andReturn(@"bar1");
+
+    MAVERemoteConfigurationTwitterShare *twitterShareConfig = [[MAVERemoteConfigurationTwitterShare alloc] init];
+    twitterShareConfig.textTemplate = templateString;
+
+    NSString *output = [twitterShareConfig text];
+
+    OCMVerifyAll(templatingUtilsMock);
+    XCTAssertEqualObjects(output, @"bar1");
 }
 
 @end

--- a/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
+++ b/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
@@ -61,10 +61,11 @@
 
 - (void)testInterpolateTemplateStringAllUserFields {
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
-    NSString *template = @"{{ user.userID }} {{ user.firstName }} {{ user.lastName }} \"{{ user.fullName }}\"";
+    user.promoCode = @"123foo";
+    NSString *template = @"{{ user.userID }} {{ user.firstName }} {{ user.lastName }} '{{ user.fullName }}' {{ user.promoCode }}";
     NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user customData:@{}];
 
-    NSString *expected = @"1 Foo Bar \"Foo Bar\"";
+    NSString *expected = @"1 Foo Bar 'Foo Bar' 123foo";
     XCTAssertEqualObjects(output, expected);
 }
 

--- a/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
+++ b/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
@@ -77,8 +77,35 @@
     XCTAssertEqualObjects(output, expected);
 }
 
-- (void)testInterpolateTemplateStringNSNumberDictionaryValues {
+- (void)testConvertValueToStringFromVariousTypes {
+    id a = @2;
+    id b = @(2.129312);
+    id c = @(YES);
+    id d = [NSNull null];
+    id e = @"string";
+    id f = [[MAVEUserData alloc] init];
 
+    XCTAssertEqualObjects([MAVETemplatingUtils convertValueToString:a], @"2");
+    XCTAssertEqualObjects([MAVETemplatingUtils convertValueToString:b], @"2.129312");
+    XCTAssertEqualObjects([MAVETemplatingUtils convertValueToString:c], @"1");
+    XCTAssertEqualObjects([MAVETemplatingUtils convertValueToString:d], @"<null>");
+    XCTAssertEqualObjects([MAVETemplatingUtils convertValueToString:e], @"string");
+    XCTAssertNil([MAVETemplatingUtils convertValueToString:f]);
+}
+
+- (void)testInterpolateTemplateStringConvertsValuesToStrings {
+    NSDictionary *customData = @{@"a": @19, @"b": @(19.55), @"c": @(YES), @"d": [NSNull null], @"e": @"string", @"f": [[MAVEUserData alloc] init]};
+    NSString *templateString = @"a {{ customData.a }} b {{ customData.b }} c {{ customData.c }} d {{ customData.d }} e {{ customData.e }} f {{ customData.f }}";
+
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:templateString withUser:nil customData:customData];
+    NSString *expected = @"a 19 b 19.55 c 1 d <null> e string f ";
+    XCTAssertEqualObjects(output, expected);
+}
+
+- (void)testInterpolateTemplateStringSkipsNonStringKeys {
+    NSDictionary *customData = @{@(19): @"foo"};
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:@"{{ customData.19 }}" withUser:nil customData:customData];
+    XCTAssertEqualObjects(output, @"");
 }
 
 - (void)testInterpolateWithSingletonData {

--- a/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
+++ b/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
@@ -1,0 +1,98 @@
+//
+//  MAVETemplatingUtilsTests.m
+//  MaveSDK
+//
+//  Created by Danny Cosson on 3/24/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "MAVETemplatingUtils.h"
+#import "MaveSDK.h"
+
+@interface MAVETemplatingUtilsTests : XCTestCase
+
+@end
+
+@implementation MAVETemplatingUtilsTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testInterpolateTemplateStringNoInterpolation {
+    MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
+    NSDictionary *customData = @{@"foo_field": @"blah"};
+    NSString *template = @"Hello there";
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user customData:customData];
+
+    NSString *expected = template;
+    XCTAssertEqualObjects(output, expected);
+}
+
+- (void)testInterpolateTemplateStringNoInterpolationNils {
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:@"Foo" withUser:nil customData:nil];
+
+    XCTAssertEqualObjects(output, @"Foo");
+}
+
+- (void)testInterpolateTemplateStringNil {
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:nil withUser:nil customData:nil];
+    XCTAssertNil(output);
+}
+
+- (void)testInterpolateTemplateStringSimpleWithUserAndCustomData {
+    MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
+    NSDictionary *customData = @{@"foo_field": @"blah"};
+    NSString *template = @"{{ user.firstName }} is \"{{customData.foo_field}}\"";
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user customData:customData];
+
+    NSString *expected = @"Foo is \"blah\"";
+    XCTAssertEqualObjects(output, expected);
+}
+
+- (void)testInterpolateTemplateStringAllUserFields {
+    MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
+    NSString *template = @"{{ user.userID }} {{ user.firstName }} {{ user.lastName }} \"{{ user.fullName }}\"";
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user customData:@{}];
+
+    NSString *expected = @"1 Foo Bar \"Foo Bar\"";
+    XCTAssertEqualObjects(output, expected);
+}
+
+- (void)testInterpolateTemplateStringMissingStringLeavesEmpty {
+    MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
+    NSString *template = @"{{ user.firstName }} is not \"{{ firstName }}\"";
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user customData:nil];
+
+    NSString *expected = @"Foo is not \"\"";
+    XCTAssertEqualObjects(output, expected);
+}
+
+- (void)testInterpolateTemplateStringNSNumberDictionaryValues {
+
+}
+
+- (void)testInterpolateWithSingletonData {
+    MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
+    user.customData = @{@"other_field": @"blahz"};
+    id maveMock = OCMPartialMock([MaveSDK sharedInstance]);
+    OCMExpect([maveMock userData]).andReturn(user);
+
+    NSString *template = @"hello {{ user.fullName }}, something else {{ customData.other_field }}";
+    NSString *output = [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:template];
+
+    OCMVerifyAll(maveMock);
+    NSString *expected = @"hello Foo Bar, something else blahz";
+    XCTAssertEqualObjects(output, expected);
+}
+
+@end

--- a/Podfile
+++ b/Podfile
@@ -3,6 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 target "DemoApp" do
   pod 'MMDrawerController', '~> 0.5.7'
   pod 'libPhoneNumber-iOS', '0.8.3'
+  pod 'CCTemplate', '0.2.0'
 end
 
 target "MaveSDKTests" do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+  - CCTemplate (0.2.0)
   - Gizou (0.1.3)
   - libPhoneNumber-iOS (0.8.3)
   - MMDrawerController (0.5.7):
@@ -16,15 +17,17 @@ PODS:
   - OCMock (3.1.2)
 
 DEPENDENCIES:
+  - CCTemplate (= 0.2.0)
   - Gizou
   - libPhoneNumber-iOS (= 0.8.3)
   - MMDrawerController (~> 0.5.7)
   - OCMock (~> 3.1.1)
 
 SPEC CHECKSUMS:
+  CCTemplate: da9e9debe44a9d1e37fc46b94f43675003f59af4
   Gizou: f0025df05b51197ab8979c728a1cd525b7d6911f
   libPhoneNumber-iOS: 640f078c832d2ded97ae24134bc009c3300686e3
   MMDrawerController: c3ab7a318ddc7e2bcd133139c3161af08c6e1197
   OCMock: ecdd510b73ef397f2f97274785c1e87fd147c49f
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.36.0


### PR DESCRIPTION
Add templating to the message copy for all invite & share types, so people can add e.g. promo code to the share messages. 

After this the only non-templated remote configuration strings are for the contacts pre-permission prompt, we can add templating there too in a future release if needed.