### PR TITLE
Client Invites

### DIFF
--- a/MaveSDK.xcodeproj/project.pbxproj
+++ b/MaveSDK.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		0C435C8D1B0FB806005B11AF /* MAVEContactsInvitePageDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C435C8C1B0FB806005B11AF /* MAVEContactsInvitePageDataManager.m */; };
 		0C44DCBF1B2207E6004780A0 /* MAVESuggestedInviteReusableTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C44DCBE1B2207E6004780A0 /* MAVESuggestedInviteReusableTableViewCell.m */; };
 		0C44DCC21B220817004780A0 /* MAVESuggestedInviteReusableCellDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C44DCC11B220817004780A0 /* MAVESuggestedInviteReusableCellDelegate.m */; };
+		0C462F5C1B5EC08C003A290C /* MAVEContactsInvitePageV3SendClientSideInvitesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C462F5B1B5EC08C003A290C /* MAVEContactsInvitePageV3SendClientSideInvitesTests.m */; };
 		0C5165161B2734A90084C636 /* MAVESuggestedInviteReusableInviteFriendsButtonTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C5165151B2734A90084C636 /* MAVESuggestedInviteReusableInviteFriendsButtonTableViewCell.m */; };
 		0C5165191B2734FE0084C636 /* MAVEInviteFriendsReusableOvalButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C5165181B2734FE0084C636 /* MAVEInviteFriendsReusableOvalButton.m */; };
 		0C5165201B27359E0084C636 /* MAVECancelX.png in Resources */ = {isa = PBXBuildFile; fileRef = 0C51651A1B27359E0084C636 /* MAVECancelX.png */; };
@@ -411,6 +412,7 @@
 		0C44DCBE1B2207E6004780A0 /* MAVESuggestedInviteReusableTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVESuggestedInviteReusableTableViewCell.m; sourceTree = "<group>"; };
 		0C44DCC01B220817004780A0 /* MAVESuggestedInviteReusableCellDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MAVESuggestedInviteReusableCellDelegate.h; sourceTree = "<group>"; };
 		0C44DCC11B220817004780A0 /* MAVESuggestedInviteReusableCellDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVESuggestedInviteReusableCellDelegate.m; sourceTree = "<group>"; };
+		0C462F5B1B5EC08C003A290C /* MAVEContactsInvitePageV3SendClientSideInvitesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVEContactsInvitePageV3SendClientSideInvitesTests.m; sourceTree = "<group>"; };
 		0C5165141B2734A90084C636 /* MAVESuggestedInviteReusableInviteFriendsButtonTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MAVESuggestedInviteReusableInviteFriendsButtonTableViewCell.h; sourceTree = "<group>"; };
 		0C5165151B2734A90084C636 /* MAVESuggestedInviteReusableInviteFriendsButtonTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVESuggestedInviteReusableInviteFriendsButtonTableViewCell.m; sourceTree = "<group>"; };
 		0C5165171B2734FE0084C636 /* MAVEInviteFriendsReusableOvalButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MAVEInviteFriendsReusableOvalButton.h; sourceTree = "<group>"; };
@@ -1294,6 +1296,7 @@
 				0C03BE681AAA33CE0008BCC0 /* MAVESharerTests.m */,
 				0C25A3F21AD6E3420031D163 /* MAVEContactsInvitePageV2ViewControllerTests.m */,
 				0CE36EBF1B1763D5005BF445 /* MAVEContactsInvitePageV3ViewControllerTests.m */,
+				0C462F5B1B5EC08C003A290C /* MAVEContactsInvitePageV3SendClientSideInvitesTests.m */,
 				0CABFAEF1B447222007E09DE /* MAVEContactsInvitePageSearchManagerTests.m */,
 				0CABFAF11B4DB8C2007E09DE /* MAVEContactsInvitePageDataManagerTests.m */,
 			);
@@ -1741,6 +1744,7 @@
 				C0425B8E19EDBFC8006641AB /* MAVEInvitePageViewControllerTests.m in Sources */,
 				0CCC92BC1A5F50A6008CB888 /* MAVEInvitePageChooserTests.m in Sources */,
 				0CD655CC1B161C6700C89935 /* MAVEContactEmailTests.m in Sources */,
+				0C462F5C1B5EC08C003A290C /* MAVEContactsInvitePageV3SendClientSideInvitesTests.m in Sources */,
 				C022641719EC41010087FF37 /* MAVEABUtilsTests.m in Sources */,
 				0C6D92BE1A759E7200B65B82 /* MAVEMerkleTree.m in Sources */,
 				0CCC92C91A603DFD008CB888 /* MAVERemoteObjectBuilderTests.m in Sources */,

--- a/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.h
+++ b/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.h
@@ -32,7 +32,7 @@
 - (void)selectOrDeselectAll:(BOOL)select;
 
 // Method to send the invites when clicking the button
-- (void)sendInvitesToSelected;
-- (void)sendInviteToAnonymousContactIdentifier:(MAVEContactIdentifierBase *)contactIdentifier successBlock:(void(^)())successBlock;
+- (void)sendRemoteInvitesToSelected;
+- (void)sendRemoteInviteToAnonymousContactIdentifier:(MAVEContactIdentifierBase *)contactIdentifier successBlock:(void(^)())successBlock;
 
 @end

--- a/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.h
+++ b/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.h
@@ -12,8 +12,12 @@
 #import "MAVEContactsInvitePageDataManager.h"
 #import "MAVEContactsInvitePageSearchManager.h"
 #import "MAVEContactsInvitePageV3TableWrapperView.h"
+#import "MAVERemoteConfigurationContactsInvitePage.h"
 
 @interface MAVEContactsInvitePageV3ViewController : UIViewController <UITableViewDataSource, UITableViewDelegate>
+
+// how we'll send the sms invites, server-side or client side
+@property (nonatomic, assign) MAVESMSInviteSendMethod inviteSendMethod;
 
 // Keep a weak reference to the wrapper view, which is really just the view
 @property (nonatomic, weak) MAVEContactsInvitePageV3TableWrapperView *wrapperView;
@@ -32,7 +36,9 @@
 - (void)selectOrDeselectAll:(BOOL)select;
 
 // Method to send the invites when clicking the button
+- (void)sendInvitesToSelected;
 - (void)sendRemoteInvitesToSelected;
 - (void)sendRemoteInviteToAnonymousContactIdentifier:(MAVEContactIdentifierBase *)contactIdentifier successBlock:(void(^)())successBlock;
+- (void)sendClientSideGroupInvitesToSelected;
 
 @end

--- a/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
+++ b/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
@@ -340,7 +340,7 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
         if (self.searchManager.useNewNumber) {
             MAVEContactPhoneNumber *phone = [[MAVEContactPhoneNumber alloc] initWithValue:self.searchManager.useNewNumber andLabel:MAVEContactPhoneLabelOther];
             if (phone) {
-                [self sendInviteToAnonymousContactIdentifier:phone successBlock:^{
+                [self sendRemoteInviteToAnonymousContactIdentifier:phone successBlock:^{
                     self.searchManager.didSendToNewNumber = YES;
                     [tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -352,7 +352,7 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
         } else if (self.searchManager.useNewEmail) {
             MAVEContactEmail *email = [[MAVEContactEmail alloc] initWithValue:self.searchManager.useNewEmail];
             if (email) {
-                [self sendInviteToAnonymousContactIdentifier:email successBlock:^{
+                [self sendRemoteInviteToAnonymousContactIdentifier:email successBlock:^{
                     self.searchManager.didSendToNewEmail = YES;
                     [tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -380,7 +380,7 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
     [self.tableView endUpdates];
 }
 
-- (void)sendInvitesToSelected {
+- (void)sendRemoteInvitesToSelected {
     [self.wrapperView.bigSendButton updateButtonToSendingStatus];
     NSArray *recipients = [self.selectedPeopleIndex allObjects];
     NSInteger numberToSend = [self.selectedContactIdentifiersIndex count];
@@ -409,7 +409,7 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
 }
 
 // Anonymous contact identifier is e.g. a phone or email that the user just typed in
-- (void)sendInviteToAnonymousContactIdentifier:(MAVEContactIdentifierBase *)contactIdentifier successBlock:(void (^)())successBlock {
+- (void)sendRemoteInviteToAnonymousContactIdentifier:(MAVEContactIdentifierBase *)contactIdentifier successBlock:(void (^)())successBlock {
     NSString *message = [MaveSDK sharedInstance].defaultSMSMessageText;
     MAVEUserData *user = [MaveSDK sharedInstance].userData;
     [[MaveSDK sharedInstance].APIInterface sendInviteToAnonymousContactIdentifier:contactIdentifier smsCopy:message senderUserID:user.userID inviteLinkDestinationURL:user.inviteLinkDestinationURL wrapInviteLink:user.wrapInviteLink customData:user.customData completionBlock:^(NSError *error, NSDictionary *responseData) {

--- a/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
+++ b/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
@@ -455,6 +455,7 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
                 }
                 case MessageComposeResultSent: {
                     eitherSendCompleted = YES;
+                    break;
                 }
             }
 //            [self.wrapperView.bigSendButton updateButtonToSentStatus];
@@ -476,7 +477,29 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
     dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
 
     if ([emailsToInvite count] > 0) {
-        dispatch_semaphore_signal(sema);
+        UIViewController *emailVC = [MAVESharer composeClientEmailInviteToRecipientEmails:emailsToInvite withCompletionBlock:^(MFMailComposeViewController *controller, MFMailComposeResult composeResult) {
+            switch (composeResult) {
+                case MFMailComposeResultCancelled: {
+                    break;
+                }
+                case MFMailComposeResultFailed: {
+                    break;
+                }
+                case MFMailComposeResultSaved: {
+                    break;
+                }
+                case MFMailComposeResultSent: {
+                    eitherSendCompleted = YES;
+                }
+            }
+            [self dismissViewControllerAnimated:controller completion:nil];
+            dispatch_semaphore_signal(sema);
+        }];
+        if (emailVC) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self presentViewController:emailVC animated:YES completion:nil];
+            });
+        }
     } else {
         dispatch_semaphore_signal(sema);
     }

--- a/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
+++ b/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
@@ -517,7 +517,7 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
         MAVEInfoLog(@"Canceled sending client side invites!");
     }
 
-    dispatch_sync(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         if (smsInvitesSent || emailInvitesSent) {
             // deselect people, only if we successfully sent to that medium
             if (smsInvitesSent) {

--- a/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
+++ b/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
@@ -470,7 +470,7 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
                     break;
                 }
             }
-            [self dismissViewControllerAnimated:controller completion:nil];
+            [controller dismissViewControllerAnimated:YES completion:nil];
             dispatch_semaphore_signal(sema);
         }];
         if (smsVC) {
@@ -501,7 +501,7 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
                     emailInvitesSent = YES;
                 }
             }
-            [self dismissViewControllerAnimated:controller completion:nil];
+            [controller dismissViewControllerAnimated:YES completion:nil];
             dispatch_semaphore_signal(sema);
         }];
         if (emailVC) {

--- a/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
+++ b/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
@@ -381,10 +381,15 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
 }
 
 - (void)sendInvitesToSelected {
-    if ([MaveSDK sharedInstance].remoteConfiguration.contactsInvitePage.smsInviteSendMethod == MAVESMSInviteSendMethodServerSide) {
-        [self sendRemoteInvitesToSelected];
-    } else {
-        [self sendClientSideGroupInvitesToSelected];
+    switch (self.inviteSendMethod) {
+        case MAVESMSInviteSendMethodClientSideGroup: {
+            [self sendClientSideGroupInvitesToSelected];
+            break;
+        }
+        case MAVESMSInviteSendMethodServerSide: {
+            [self sendRemoteInvitesToSelected];
+            break;
+        }
     }
 }
 

--- a/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
+++ b/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
@@ -510,31 +510,6 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
 
     dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
 
-    // Show alerts if any failures
-    if (smsInvitesFailed) {
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"SMS failed to send" message:nil delegate:nil cancelButtonTitle:nil otherButtonTitles:nil];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [alert show];
-        });
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            [alert dismissWithClickedButtonIndex:0 animated:YES];
-            dispatch_semaphore_signal(sema);
-        });
-        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
-    }
-
-    if (emailinvitesFailed) {
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Email failed to send" message:nil delegate:nil cancelButtonTitle:nil otherButtonTitles:nil];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [alert show];
-        });
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            [alert dismissWithClickedButtonIndex:0 animated:YES];
-            dispatch_semaphore_signal(sema);
-        });
-        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
-    }
-
     // Log what happened
     if (smsInvitesSent || emailInvitesSent) {
         MAVEInfoLog(@"Sent client side invites!");

--- a/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
+++ b/MaveSDK/Controllers/MAVEContactsInvitePageV3ViewController.m
@@ -423,7 +423,6 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
 }
 
 - (void)_syncSendClientSideGroupInvitesToSelected {
-    NSLog(@"client side group invites!");
     NSArray *recipients = [self.selectedPeopleIndex allObjects];
     NSMutableArray *_phoneRecipients = [[NSMutableArray alloc] init];
     NSMutableArray *_emailRecipients = [[NSMutableArray alloc] init];
@@ -543,7 +542,7 @@ NSString * const MAVEContactsInvitePageV3CellIdentifier = @"MAVEContactsInvitePa
         MAVEInfoLog(@"Canceled sending client side invites!");
     }
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_sync(dispatch_get_main_queue(), ^{
         if (smsInvitesSent || emailInvitesSent) {
             // deselect people, only if we successfully sent to that medium
             if (smsInvitesSent) {

--- a/MaveSDK/Controllers/MAVEInvitePageChooser.h
+++ b/MaveSDK/Controllers/MAVEInvitePageChooser.h
@@ -54,6 +54,9 @@ extern NSString * const MAVEInvitePagePresentFormatPush;
 - (MFMessageComposeViewController *)createClientSMSInvitePage;
 
 // Helpers for business logic
+- (BOOL)isAnyContactsInvitePageAllowed;
+- (BOOL)isServerSideSMSAllowed;
+// deprecated with invite page v1 & v2: both of the previous checks combined
 - (BOOL)isAnyServerSideContactsInvitePageAllowed;
 - (BOOL)isInSupportedRegionForServerSideSMSInvites;
 // TODO: deprecate the following, we can remove this kill switch b/c we can use

--- a/MaveSDK/Controllers/MAVEInvitePageChooser.m
+++ b/MaveSDK/Controllers/MAVEInvitePageChooser.m
@@ -109,8 +109,16 @@ NSString * const MAVEInvitePagePresentFormatPush = @"push";
 }
 
 - (MAVEContactsInvitePageV3ViewController *)createContactsInvitePageV3IfAllowed {
-    if ([self isAnyServerSideContactsInvitePageAllowed]) {
-        return [[MAVEContactsInvitePageV3ViewController alloc] init];
+    if ([self isAnyContactsInvitePageAllowed]) {
+        MAVEContactsInvitePageV3ViewController *vc = [[MAVEContactsInvitePageV3ViewController alloc] init];
+        MAVESMSInviteSendMethod sendMethod = [MaveSDK sharedInstance].remoteConfiguration.contactsInvitePage.smsInviteSendMethod;
+        if (sendMethod == MAVESMSInviteSendMethodServerSide &&
+            [self isServerSideSMSAllowed]) {
+            vc.inviteSendMethod = MAVESMSInviteSendMethodServerSide;
+        } else {
+            vc.inviteSendMethod = MAVESMSInviteSendMethodClientSideGroup;
+        }
+        return vc;
     } else {
         return nil;
     }

--- a/MaveSDK/Controllers/MAVEInvitePageChooser.m
+++ b/MaveSDK/Controllers/MAVEInvitePageChooser.m
@@ -116,7 +116,7 @@ NSString * const MAVEInvitePagePresentFormatPush = @"push";
     }
 }
 
-
+// deprecated, remove once invite page v1 & v2 are removed
 - (BOOL)isAnyServerSideContactsInvitePageAllowed {
     // Once we fully support client-side invite send method, incorporate that option
     // into the logic:
@@ -138,6 +138,39 @@ NSString * const MAVEInvitePagePresentFormatPush = @"push";
     // If configured server-side to turn off contacts invite page, return nil
     if (![self isContactsInvitePageEnabledServerSide]) {
         MAVEInfoLog(@"Using fallback invite page b/c contacts page set to NO server-side");
+        return NO;
+    }
+
+    // If user data doesn't have a legit user id & first name, can't send server-side SMS
+    // so use share page instead
+    if (![[MaveSDK sharedInstance].userData isUserInfoOkToSendServerSideSMS]) {
+        MAVEInfoLog(@"Fallback to custom share page b/c user info invalid");
+        return NO;
+    }
+    return YES;
+}
+
+- (BOOL)isAnyContactsInvitePageAllowed {
+    // If contacts permission already denied, return NO
+    NSString *addressBookStatus = [MAVEABUtils addressBookPermissionStatus];
+    if (addressBookStatus == MAVEABPermissionStatusDenied) {
+        MAVEInfoLog(@"Using fallback invite page b/c address book permission already denied");
+        return NO;
+    }
+
+    // If configured server-side to turn off contacts invite page, return NO
+    if (![self isContactsInvitePageEnabledServerSide]) {
+        MAVEInfoLog(@"Using fallback invite page b/c contacts page set to NO server-side");
+        return NO;
+    }
+
+    return YES;
+}
+
+- (BOOL)isServerSideSMSAllowed {
+    // If not in a supported region, return NO
+    if (![self isInSupportedRegionForServerSideSMSInvites]) {
+        MAVEInfoLog(@"Using fallback invite page b/c not in supported region for server-side SMS");
         return NO;
     }
 

--- a/MaveSDK/Controllers/MAVESharer.h
+++ b/MaveSDK/Controllers/MAVESharer.h
@@ -32,7 +32,7 @@ extern NSString * const MAVESharePageShareTypeClipboard;
 // Methods to compose and share, they return UIViewControllers that need to be presented to display the compose views
 //
 + (MFMessageComposeViewController *)composeClientSMSInviteToRecipientPhones:(NSArray *)recipientPhones completionBlock:(void(^)(MFMessageComposeViewController *controller, MessageComposeResult composeResult))completionBlock;
-+ (MFMailComposeViewController *)composeClientEmailWithCompletionBlock:(void(^)(MFMailComposeViewController *controller, MFMailComposeResult result))completionBlock;
++ (MFMailComposeViewController *)composeClientEmailInviteToRecipientEmails:(NSArray *)recipients withCompletionBlock:(void (^)(MFMailComposeViewController *, MFMailComposeResult))completionBlock;
 + (SLComposeViewController *)composeFacebookNativeShareWithCompletionBlock:(void(^)(SLComposeViewController *controller, SLComposeViewControllerResult result)) completionBlock;
 + (SLComposeViewController *)composeTwitterNativeShareWithCompletionBlock:(void(^)(SLComposeViewController *controller, SLComposeViewControllerResult result)) completionBlock;
 + (void)composePasteboardShare;

--- a/MaveSDK/Controllers/MAVESharer.m
+++ b/MaveSDK/Controllers/MAVESharer.m
@@ -83,7 +83,7 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
 
 #pragma mark - client Email
 
-+ (MFMailComposeViewController *)composeClientEmailWithCompletionBlock:(void (^)(MFMailComposeViewController *, MFMailComposeResult))completionBlock {
++ (MFMailComposeViewController *)composeClientEmailInviteToRecipientEmails:(NSArray *)recipients withCompletionBlock:(void (^)(MFMailComposeViewController *, MFMailComposeResult))completionBlock {
     if (![MFMailComposeViewController canSendMail]) {
         MAVEErrorLog(@"Tried to do compose client email but canSendMail is false");
         if (completionBlock) {
@@ -100,6 +100,7 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
     NSString *message = [self shareCopyFromCopy:ownInstance.remoteConfiguration.clientEmail.body
                                    andLinkWithSubRouteLetter:@"e"];
 
+    composeVC.bccRecipients = recipients;
     composeVC.mailComposeDelegate = ownInstance;
     composeVC.subject = subject;
     [composeVC setMessageBody:message isHTML:NO];

--- a/MaveSDK/Controllers/MAVESharer.m
+++ b/MaveSDK/Controllers/MAVESharer.m
@@ -100,7 +100,9 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
     NSString *message = [self shareCopyFromCopy:ownInstance.remoteConfiguration.clientEmail.body
                                    andLinkWithSubRouteLetter:@"e"];
 
-    composeVC.bccRecipients = recipients;
+    if ([recipients count] > 0) {
+        composeVC.bccRecipients = recipients;
+    }
     composeVC.mailComposeDelegate = ownInstance;
     composeVC.subject = subject;
     [composeVC setMessageBody:message isHTML:NO];

--- a/MaveSDK/Controllers/MAVESharer.m
+++ b/MaveSDK/Controllers/MAVESharer.m
@@ -39,6 +39,9 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
 + (MFMessageComposeViewController *)composeClientSMSInviteToRecipientPhones:(NSArray *)recipientPhones completionBlock:(void (^)(MFMessageComposeViewController *controller, MessageComposeResult composeResult))completionBlock {
     if (![MFMessageComposeViewController canSendText]) {
         MAVEErrorLog(@"Tried to do compose client sms but canSendText is false");
+        if (completionBlock) {
+            completionBlock(nil, MessageComposeResultFailed);
+        }
         return nil;
     }
     MAVESharer *ownInstance = [MAVESharerViewControllerBuilder sharerInstanceRetained];
@@ -81,6 +84,13 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
 #pragma mark - client Email
 
 + (MFMailComposeViewController *)composeClientEmailWithCompletionBlock:(void (^)(MFMailComposeViewController *, MFMailComposeResult))completionBlock {
+    if (![MFMailComposeViewController canSendMail]) {
+        MAVEErrorLog(@"Tried to do compose client email but canSendMail is false");
+        if (completionBlock) {
+            completionBlock(nil, MFMailComposeResultFailed);
+        }
+        return nil;
+    }
 
     MAVESharer *ownInstance = [MAVESharerViewControllerBuilder sharerInstanceRetained];
     ownInstance.completionBlockClientEmail = completionBlock;

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePage.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePage.m
@@ -73,7 +73,7 @@ NSString * const MAVERemoteConfigKeyContactsInvitePageSMSSendMethodClientSideGro
             } else {
                 self.smsInviteSendMethod = MAVESMSInviteSendMethodServerSide;
             }
-            self.smsInviteSendMethod = MAVESMSInviteSendMethodClientSideGroup;
+
             // Set the reusable icon if it was passed in the template, otherwise default to airplane
             NSString *reusableSuggestedInviteCellSendIcon = [template objectForKey:MAVERemoteConfigKeyContactsInvitePageReusableSuggestedInviteCellSendIcon];
             if (reusableSuggestedInviteCellSendIcon != (id)[NSNull null] &&

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePage.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePage.m
@@ -73,6 +73,7 @@ NSString * const MAVERemoteConfigKeyContactsInvitePageSMSSendMethodClientSideGro
             } else {
                 self.smsInviteSendMethod = MAVESMSInviteSendMethodServerSide;
             }
+            self.smsInviteSendMethod = MAVESMSInviteSendMethodClientSideGroup;
             // Set the reusable icon if it was passed in the template, otherwise default to airplane
             NSString *reusableSuggestedInviteCellSendIcon = [template objectForKey:MAVERemoteConfigKeyContactsInvitePageReusableSuggestedInviteCellSendIcon];
             if (reusableSuggestedInviteCellSendIcon != (id)[NSNull null] &&

--- a/MaveSDK/Views/MAVEShareButtonsView.m
+++ b/MaveSDK/Views/MAVEShareButtonsView.m
@@ -259,7 +259,7 @@ CGFloat const MAVEShareIconsSmallIconsEdgeSize = 22;
 }
 
 - (void)doClientEmailShare {
-    UIViewController *vc = [MAVESharer composeClientEmailWithCompletionBlock:^(MFMailComposeViewController *controller, MFMailComposeResult result) {
+    UIViewController *vc = [MAVESharer composeClientEmailInviteToRecipientEmails:nil withCompletionBlock:^(MFMailComposeViewController *controller, MFMailComposeResult result) {
         [controller dismissViewControllerAnimated:YES completion:nil];
         if (result == MFMailComposeResultSent) {
             [self afterShareActions];

--- a/MaveSDKTests/Controllers/MAVEContactsInvitePageV3SendClientSideInvitesTests.m
+++ b/MaveSDKTests/Controllers/MAVEContactsInvitePageV3SendClientSideInvitesTests.m
@@ -1,0 +1,275 @@
+//
+//  MAVEContactsInvitePageV3SendClientSideInvitesTests.m
+//  MaveSDK
+//
+//  Created by Danny Cosson on 7/21/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+
+#import "MAVEContactsInvitePageV3ViewController.h"
+#import "MAVESharer.h"
+
+@interface MAVEContactsInvitePageV3SendClientSideInvitesTests : XCTestCase
+
+@end
+
+@interface MAVEContactsInvitePageV3ViewController(Testing)
+- (void)_syncSendClientSideGroupInvitesToSelected;
+@end
+
+@implementation MAVEContactsInvitePageV3SendClientSideInvitesTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testSendClientSideInvitesSMSAndEmail {
+    MAVEContactsInvitePageV3ViewController *controller = [[MAVEContactsInvitePageV3ViewController alloc] init];
+    [controller viewDidLoad];
+
+    MAVEABPerson *p0 = [[MAVEABPerson alloc] init];
+    MAVEContactEmail *email00 = [[MAVEContactEmail alloc] initWithValue:@"bar@example.com"];
+    MAVEContactEmail *email01 = [[MAVEContactEmail alloc] initWithValue:@"foo@example.com"];
+    p0.emailObjects = @[email00, email01];
+    p0.selected = YES; email00.selected = YES; email01.selected = NO;
+    [controller updateToReflectPersonSelectedStatus:p0];
+
+    MAVEABPerson *p1 = [[MAVEABPerson alloc] init];
+    MAVEContactPhoneNumber *phone1 = [[MAVEContactPhoneNumber alloc] initWithValue:@"+18085551234" andLabel:MAVEContactPhoneLabelMobile];
+    p1.phoneObjects = @[phone1];
+    p1.selected = YES; phone1.selected = YES;
+    [controller updateToReflectPersonSelectedStatus:p1];
+
+    // Mock sharer to test that we launched sms and email share pages
+    id sharerMock = OCMClassMock([MAVESharer class]);
+    NSArray *invitePhones = @[phone1.value];
+    OCMExpect([sharerMock composeClientSMSInviteToRecipientPhones:invitePhones completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
+        void(^completionBlock)(MFMessageComposeViewController *, MessageComposeResult) = obj;
+        completionBlock(nil, MessageComposeResultSent);
+        return YES;
+    }]]);
+    NSArray *inviteEmails = @[email00.value];
+    OCMExpect([sharerMock composeClientEmailInviteToRecipientEmails:inviteEmails withCompletionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
+        void(^completionBlock)(MFMailComposeViewController *, MFMailComposeResult) = obj;
+        completionBlock(nil, MFMailComposeResultSent);
+        return YES;
+    }]]);
+
+    [controller _syncSendClientSideGroupInvitesToSelected];
+
+    OCMVerifyAll(sharerMock);
+    // after sending, people should no longer be selected
+
+    // Wait for them to become unselected on main run loop.
+    // (can't just wait here using GCD b/c test is running on main loop so if we
+    // block then any dispatches to main queue in the code won't ever run)
+    NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:5];
+    while ([loopUntil timeIntervalSinceNow] > 0) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:loopUntil];
+        if (!p0.selected && !p1.selected) {
+            break;
+        }
+    }
+    XCTAssertFalse(p0.selected);
+    XCTAssertFalse(p1.selected);
+}
+
+- (void)testSendClientSideInvitesSMSAndEmailWhenSMSNotSent {
+    MAVEContactsInvitePageV3ViewController *controller = [[MAVEContactsInvitePageV3ViewController alloc] init];
+    [controller viewDidLoad];
+
+    MAVEABPerson *p0 = [[MAVEABPerson alloc] init];
+    MAVEContactEmail *email00 = [[MAVEContactEmail alloc] initWithValue:@"bar@example.com"];
+    MAVEContactEmail *email01 = [[MAVEContactEmail alloc] initWithValue:@"foo@example.com"];
+    p0.emailObjects = @[email00, email01];
+    p0.selected = YES; email00.selected = YES; email01.selected = NO;
+    [controller updateToReflectPersonSelectedStatus:p0];
+
+    MAVEABPerson *p1 = [[MAVEABPerson alloc] init];
+    MAVEContactPhoneNumber *phone1 = [[MAVEContactPhoneNumber alloc] initWithValue:@"+18085551234" andLabel:MAVEContactPhoneLabelMobile];
+    p1.phoneObjects = @[phone1];
+    p1.selected = YES; phone1.selected = YES;
+    [controller updateToReflectPersonSelectedStatus:p1];
+
+    // Mock sharer to test that we launched sms and email share pages
+    id sharerMock = OCMClassMock([MAVESharer class]);
+    NSArray *invitePhones = @[phone1.value];
+    OCMExpect([sharerMock composeClientSMSInviteToRecipientPhones:invitePhones completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
+        void(^completionBlock)(MFMessageComposeViewController *, MessageComposeResult) = obj;
+        completionBlock(nil, MessageComposeResultCancelled);
+        return YES;
+    }]]);
+    NSArray *inviteEmails = @[email00.value];
+    OCMExpect([sharerMock composeClientEmailInviteToRecipientEmails:inviteEmails withCompletionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
+        void(^completionBlock)(MFMailComposeViewController *, MFMailComposeResult) = obj;
+        completionBlock(nil, MFMailComposeResultSent);
+        return YES;
+    }]]);
+
+    [controller _syncSendClientSideGroupInvitesToSelected];
+
+    OCMVerifyAll(sharerMock);
+    // after sending, person with email should still be selected but person with
+    // phone should not
+
+    // Wait for them to become unselected on main run loop.
+    // (can't just wait here using GCD b/c test is running on main loop so if we
+    // block then any dispatches to main queue in the code won't ever run)
+    NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:5];
+    while ([loopUntil timeIntervalSinceNow] > 0) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:loopUntil];
+        if (!p0.selected) {
+            break;
+        }
+    }
+    XCTAssertFalse(p0.selected);
+    XCTAssertTrue(p1.selected);
+}
+
+- (void)testSendClientSideInvitesSMSAndEmailWhenEmailNotSent {
+    MAVEContactsInvitePageV3ViewController *controller = [[MAVEContactsInvitePageV3ViewController alloc] init];
+    [controller viewDidLoad];
+
+    MAVEABPerson *p0 = [[MAVEABPerson alloc] init];
+    MAVEContactEmail *email00 = [[MAVEContactEmail alloc] initWithValue:@"bar@example.com"];
+    MAVEContactEmail *email01 = [[MAVEContactEmail alloc] initWithValue:@"foo@example.com"];
+    p0.emailObjects = @[email00, email01];
+    p0.selected = YES; email00.selected = YES; email01.selected = NO;
+    [controller updateToReflectPersonSelectedStatus:p0];
+
+    MAVEABPerson *p1 = [[MAVEABPerson alloc] init];
+    MAVEContactPhoneNumber *phone1 = [[MAVEContactPhoneNumber alloc] initWithValue:@"+18085551234" andLabel:MAVEContactPhoneLabelMobile];
+    p1.phoneObjects = @[phone1];
+    p1.selected = YES; phone1.selected = YES;
+    [controller updateToReflectPersonSelectedStatus:p1];
+
+    // Mock sharer to test that we launched sms and email share pages
+    id sharerMock = OCMClassMock([MAVESharer class]);
+    NSArray *invitePhones = @[phone1.value];
+    OCMExpect([sharerMock composeClientSMSInviteToRecipientPhones:invitePhones completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
+        void(^completionBlock)(MFMessageComposeViewController *, MessageComposeResult) = obj;
+        completionBlock(nil, MessageComposeResultSent);
+        return YES;
+    }]]);
+    NSArray *inviteEmails = @[email00.value];
+    OCMExpect([sharerMock composeClientEmailInviteToRecipientEmails:inviteEmails withCompletionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
+        void(^completionBlock)(MFMailComposeViewController *, MFMailComposeResult) = obj;
+        completionBlock(nil, MFMailComposeResultSaved);
+        return YES;
+    }]]);
+
+    [controller _syncSendClientSideGroupInvitesToSelected];
+
+    OCMVerifyAll(sharerMock);
+    // after sending, person with email should still be selected but person with
+    // phone should not
+
+    // Wait for them to become unselected on main run loop.
+    // (can't just wait here using GCD b/c test is running on main loop so if we
+    // block then any dispatches to main queue in the code won't ever run)
+    NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:5];
+    while ([loopUntil timeIntervalSinceNow] > 0) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:loopUntil];
+        if (!p1.selected) {
+            break;
+        }
+    }
+    XCTAssertTrue(p0.selected);
+    XCTAssertFalse(p1.selected);
+}
+
+- (void)testSendClientSideInvitesSMSOnly {
+    MAVEContactsInvitePageV3ViewController *controller = [[MAVEContactsInvitePageV3ViewController alloc] init];
+    [controller viewDidLoad];
+
+    MAVEABPerson *p1 = [[MAVEABPerson alloc] init];
+    MAVEContactPhoneNumber *phone1 = [[MAVEContactPhoneNumber alloc] initWithValue:@"+18085551234" andLabel:MAVEContactPhoneLabelMobile];
+    p1.phoneObjects = @[phone1];
+    p1.selected = YES; phone1.selected = YES;
+    [controller updateToReflectPersonSelectedStatus:p1];
+
+    // Mock sharer to test that we launched sms and email share pages
+    id sharerMock = OCMClassMock([MAVESharer class]);
+    NSArray *invitePhones = @[phone1.value];
+    OCMExpect([sharerMock composeClientSMSInviteToRecipientPhones:invitePhones completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
+        void(^completionBlock)(MFMessageComposeViewController *, MessageComposeResult) = obj;
+        completionBlock(nil, MessageComposeResultSent);
+        return YES;
+    }]]);
+    [[sharerMock reject] composeClientEmailInviteToRecipientEmails:[OCMArg any] withCompletionBlock:[OCMArg any]];
+
+    [controller _syncSendClientSideGroupInvitesToSelected];
+
+    OCMVerifyAll(sharerMock);
+    // after sending, people should no longer be selected
+
+    // Wait for them to become unselected on main run loop.
+    // (can't just wait here using GCD b/c test is running on main loop so if we
+    // block then any dispatches to main queue in the code won't ever run)
+    NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:5];
+    while ([loopUntil timeIntervalSinceNow] > 0) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:loopUntil];
+        if (!p1.selected) {
+            break;
+        }
+    }
+    XCTAssertFalse(p1.selected);
+}
+
+- (void)testSendClientSideInvitesEmailOnly {
+    MAVEContactsInvitePageV3ViewController *controller = [[MAVEContactsInvitePageV3ViewController alloc] init];
+    [controller viewDidLoad];
+
+    MAVEABPerson *p0 = [[MAVEABPerson alloc] init];
+    MAVEContactEmail *email00 = [[MAVEContactEmail alloc] initWithValue:@"bar@example.com"];
+    MAVEContactEmail *email01 = [[MAVEContactEmail alloc] initWithValue:@"foo@example.com"];
+    p0.emailObjects = @[email00, email01];
+    p0.selected = YES; email00.selected = YES; email01.selected = NO;
+    [controller updateToReflectPersonSelectedStatus:p0];
+
+    // Mock sharer to test that we launched sms and email share pages
+    id sharerMock = OCMClassMock([MAVESharer class]);
+    [[sharerMock reject] composeClientSMSInviteToRecipientPhones:[OCMArg any] completionBlock:[OCMArg any]];
+
+    NSArray *inviteEmails = @[email00.value];
+    OCMExpect([sharerMock composeClientEmailInviteToRecipientEmails:inviteEmails withCompletionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
+        void(^completionBlock)(MFMailComposeViewController *, MFMailComposeResult) = obj;
+        completionBlock(nil, MFMailComposeResultSent);
+        return YES;
+    }]]);
+
+    [controller _syncSendClientSideGroupInvitesToSelected];
+
+    OCMVerifyAll(sharerMock);
+    // after sending, people should no longer be selected
+
+    // Wait for them to become unselected on main run loop.
+    // (can't just wait here using GCD b/c test is running on main loop so if we
+    // block then any dispatches to main queue in the code won't ever run)
+    NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:5];
+    while ([loopUntil timeIntervalSinceNow] > 0) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:loopUntil];
+        if (!p0.selected) {
+            break;
+        }
+    }
+    XCTAssertFalse(p0.selected);
+}
+
+
+@end

--- a/MaveSDKTests/Controllers/MAVEContactsInvitePageV3ViewControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVEContactsInvitePageV3ViewControllerTests.m
@@ -328,6 +328,10 @@
     [controller _syncSendClientSideGroupInvitesToSelected];
 
     OCMVerifyAll(sharerMock);
+
+    // after sending, people should no longer be selected
+    XCTAssertFalse(p0.selected);
+    XCTAssertFalse(p1.selected);
 }
 
 @end

--- a/MaveSDKTests/Controllers/MAVEContactsInvitePageV3ViewControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVEContactsInvitePageV3ViewControllerTests.m
@@ -278,7 +278,7 @@
 //    OCMExpect([apiInterfaceMock sendInvitesToRecipients:people smsCopy:mave.defaultSMSMessageText senderUserID:mave.userData.userID inviteLinkDestinationURL:mave.userData.inviteLinkDestinationURL wrapInviteLink:mave.userData.wrapInviteLink customData:mave.userData.customData completionBlock:[OCMArg any]]);
     OCMExpect([apiInterfaceMock sendInvitesToRecipients:[OCMArg any] smsCopy:[OCMArg any] senderUserID:[OCMArg any] inviteLinkDestinationURL:[OCMArg any] wrapInviteLink:YES customData:[OCMArg any] completionBlock:[OCMArg any]]);
 
-    [controller sendInvitesToSelected];
+    [controller sendRemoteInvitesToSelected];
 
     OCMVerifyAll(apiInterfaceMock);
     mave.defaultSMSMessageText = nil;

--- a/MaveSDKTests/Controllers/MAVEContactsInvitePageV3ViewControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVEContactsInvitePageV3ViewControllerTests.m
@@ -229,6 +229,32 @@
     XCTAssertFalse(email1.selected);
 }
 
+- (void)testSendInvitesWhenClientSide {
+    // Test code that chooses whether we send remote or client invites
+    MAVEContactsInvitePageV3ViewController *controller = [[MAVEContactsInvitePageV3ViewController alloc] init];
+    controller.inviteSendMethod = MAVESMSInviteSendMethodClientSideGroup;
+    [controller viewDidLoad];
+
+    id mock = OCMPartialMock(controller);
+    OCMExpect([mock sendClientSideGroupInvitesToSelected]);
+    [controller sendInvitesToSelected];
+
+    OCMVerifyAll(mock);
+}
+
+- (void)testSendInvitesWhenRemote {
+    // Test code that chooses whether we send remote or client invites
+    MAVEContactsInvitePageV3ViewController *controller = [[MAVEContactsInvitePageV3ViewController alloc] init];
+    controller.inviteSendMethod = MAVESMSInviteSendMethodServerSide;
+    [controller viewDidLoad];
+
+    id mock = OCMPartialMock(controller);
+    OCMExpect([mock sendRemoteInvitesToSelected]);
+    [controller sendInvitesToSelected];
+
+    OCMVerifyAll(mock);
+}
+
 - (void)testSendRemoteInvites {
     [MaveSDK resetSharedInstanceForTesting];
     [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
@@ -283,8 +309,6 @@
     OCMVerifyAll(apiInterfaceMock);
     mave.defaultSMSMessageText = nil;
 }
-
-#pragma mark - Send Invites client side tests
 
 
 @end

--- a/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
+++ b/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
@@ -225,6 +225,7 @@
     XCTAssertNil(vc);
 }
 
+// deprecated
 - (void)testIsAnyServerSideContactsInvitePageAllowed {
     id abUtilsMock = OCMClassMock([MAVEABUtils class]);
     OCMStub([abUtilsMock addressBookPermissionStatus]).andReturn(MAVEABPermissionStatusAllowed);
@@ -239,7 +240,42 @@
 
     XCTAssertTrue([chooser isAnyServerSideContactsInvitePageAllowed]);
 }
+- (void)testIsServerSMSAllowedYES {
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
+    // check 1: is in supported region yes
+    OCMExpect([chooserMock isInSupportedRegionForServerSideSMSInvites]).andReturn(YES);
+    // dont need contacts invite page enabled for this check
+    [[chooserMock reject] isContactsInvitePageEnabledServerSide];
+    // check 2: user data ok yes
+    MAVEUserData *okUserData = [[MAVEUserData alloc] init];
+    okUserData.userID = @"1234"; okUserData.firstName = @"Foo";
+    [MaveSDK sharedInstance].userData = okUserData;
 
+    XCTAssertTrue([chooser isServerSideSMSAllowed]);
+    OCMVerifyAll(chooserMock);
+}
+- (void)testIsAnyContactsInvitePageAllowedYES {
+    id abUtilsMock = OCMClassMock([MAVEABUtils class]);
+    // check 1: is address book status enabled
+    OCMExpect([abUtilsMock addressBookPermissionStatus]).andReturn(MAVEABPermissionStatusAllowed);
+
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
+    // check 2, is page enabled server side
+    OCMExpect([chooserMock isContactsInvitePageEnabledServerSide]).andReturn(YES);
+    // no need to check this
+    [[chooserMock reject] isInSupportedRegionForServerSideSMSInvites];
+    // dont need user data for this check
+    [MaveSDK sharedInstance].userData = nil;
+
+    XCTAssertTrue([chooser isAnyContactsInvitePageAllowed]);
+
+    OCMVerifyAll(chooserMock);
+    OCMVerifyAll(abUtilsMock);
+}
+
+// deprecated
 - (void)testIsAnyServerSideContactsInvitePageNotAllowedWhenABPermissionStatusDenied {
     id abUtilsMock = OCMClassMock([MAVEABUtils class]);
     OCMStub([abUtilsMock addressBookPermissionStatus]).andReturn(MAVEABPermissionStatusDenied);
@@ -248,18 +284,16 @@
 
     XCTAssertFalse([chooser isAnyServerSideContactsInvitePageAllowed]);
 }
-
-- (void)testIsAnyServerSideContactsInvitePageNotAllowedWhenNotInSupportedRegion {
+- (void)testIsAnyContactsInvitePageAllowedNOWhenABPermissionStatusDenied {
     id abUtilsMock = OCMClassMock([MAVEABUtils class]);
-    OCMStub([abUtilsMock addressBookPermissionStatus]).andReturn(MAVEABPermissionStatusAllowed);
+    OCMStub([abUtilsMock addressBookPermissionStatus]).andReturn(MAVEABPermissionStatusDenied);
 
     MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
-    id chooserMock = OCMPartialMock(chooser);
-    OCMStub([chooserMock isInSupportedRegionForServerSideSMSInvites]).andReturn(NO);
 
-    XCTAssertFalse([chooser isAnyServerSideContactsInvitePageAllowed]);
+    XCTAssertFalse([chooser isAnyContactsInvitePageAllowed]);
 }
 
+// deprecated
 - (void)testIsAnyServerSideContactsInvitePageNotAllowedWhenDisabledServerSide {
     id abUtilsMock = OCMClassMock([MAVEABUtils class]);
     OCMStub([abUtilsMock addressBookPermissionStatus]).andReturn(MAVEABPermissionStatusAllowed);
@@ -271,7 +305,39 @@
 
     XCTAssertFalse([chooser isAnyServerSideContactsInvitePageAllowed]);
 }
+- (void)testIsAnyContactsInvitePageAllowedNOWhenNotEnabledServerSide {
+    id abUtilsMock = OCMClassMock([MAVEABUtils class]);
+    OCMStub([abUtilsMock addressBookPermissionStatus]).andReturn(MAVEABPermissionStatusAllowed);
 
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
+    OCMExpect([chooserMock isContactsInvitePageEnabledServerSide]).andReturn(NO);
+
+    XCTAssertFalse([chooser isAnyServerSideContactsInvitePageAllowed]);
+    OCMVerifyAll(chooserMock);
+}
+
+// deprecated
+- (void)testIsAnyServerSideContactsInvitePageNotAllowedWhenNotInSupportedRegion {
+    id abUtilsMock = OCMClassMock([MAVEABUtils class]);
+    OCMStub([abUtilsMock addressBookPermissionStatus]).andReturn(MAVEABPermissionStatusAllowed);
+
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
+    OCMStub([chooserMock isInSupportedRegionForServerSideSMSInvites]).andReturn(NO);
+
+    XCTAssertFalse([chooser isAnyServerSideContactsInvitePageAllowed]);
+}
+- (void)testIsServerSideSMSAllowedNOWhenNotInSuportedRegion {
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
+    OCMExpect([chooserMock isInSupportedRegionForServerSideSMSInvites]).andReturn(NO);
+
+    XCTAssertFalse([chooser isServerSideSMSAllowed]);
+    OCMVerifyAll(chooserMock);
+}
+
+// deprecated
 - (void)testIsAnyServerSideContactsInvitePageNotAllowedWhenUserDataNotOK {
     id abUtilsMock = OCMClassMock([MAVEABUtils class]);
     OCMStub([abUtilsMock addressBookPermissionStatus]).andReturn(MAVEABPermissionStatusAllowed);
@@ -284,6 +350,16 @@
     [MaveSDK sharedInstance].userData = notOKUserData;
 
     XCTAssertFalse([chooser isAnyServerSideContactsInvitePageAllowed]);
+}
+- (void)testIsServerSideSMSAllowedNOWhenUserDataNotOK {
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
+    OCMExpect([chooserMock isInSupportedRegionForServerSideSMSInvites]).andReturn(YES);
+    MAVEUserData *notOKUserData = [[MAVEUserData alloc] init];
+    [MaveSDK sharedInstance].userData = notOKUserData;
+
+    XCTAssertFalse([chooser isAnyServerSideContactsInvitePageAllowed]);
+    OCMVerifyAll(chooserMock);
 }
 
 - (void)testCreateClientSMSInvitePageCleanupOnInviteSent {

--- a/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
+++ b/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
@@ -97,6 +97,87 @@
     OCMVerifyAll(chooserMock);
 }
 
+- (void)testCreateContactsInvitePageV3IfAllowedWhenServerSide {
+    MAVERemoteConfigurationContactsInvitePage *invitePageConfig = [[MAVERemoteConfigurationContactsInvitePage alloc] init];
+    invitePageConfig.smsInviteSendMethod = MAVESMSInviteSendMethodServerSide;
+    id maveMock = OCMPartialMock([MaveSDK sharedInstance]);
+    MAVERemoteConfiguration *remoteConfig = [[MAVERemoteConfiguration alloc] init];
+    remoteConfig.contactsInvitePage = invitePageConfig;
+    OCMStub([maveMock remoteConfiguration]).andReturn(remoteConfig);
+
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
+    OCMExpect([chooserMock isServerSideSMSAllowed]).andReturn(YES);
+    OCMExpect([chooserMock isAnyContactsInvitePageAllowed]).andReturn(YES);
+
+    MAVEContactsInvitePageV3ViewController *vc = [chooser createContactsInvitePageV3IfAllowed];
+
+    XCTAssertNotNil(vc);
+    XCTAssertEqual(vc.inviteSendMethod, MAVESMSInviteSendMethodServerSide);
+    OCMVerifyAll(chooserMock);
+}
+
+- (void)testCreateContactsInvitePageV3IfAllowedWhenServerSideButServerSideNotAllowed {
+    MAVERemoteConfigurationContactsInvitePage *invitePageConfig = [[MAVERemoteConfigurationContactsInvitePage alloc] init];
+    invitePageConfig.smsInviteSendMethod = MAVESMSInviteSendMethodServerSide;
+    id maveMock = OCMPartialMock([MaveSDK sharedInstance]);
+    MAVERemoteConfiguration *remoteConfig = [[MAVERemoteConfiguration alloc] init];
+    remoteConfig.contactsInvitePage = invitePageConfig;
+    OCMStub([maveMock remoteConfiguration]).andReturn(remoteConfig);
+
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
+    OCMExpect([chooserMock isServerSideSMSAllowed]).andReturn(NO);
+    OCMExpect([chooserMock isAnyContactsInvitePageAllowed]).andReturn(YES);
+
+    MAVEContactsInvitePageV3ViewController *vc = [chooser createContactsInvitePageV3IfAllowed];
+
+    XCTAssertNotNil(vc);
+    XCTAssertEqual(vc.inviteSendMethod, MAVESMSInviteSendMethodClientSideGroup);
+    OCMVerifyAll(chooserMock);
+}
+
+- (void)testCreateContactsInvitePageV3IfAllowedWhenChosenClientSideGroup {
+    MAVERemoteConfigurationContactsInvitePage *invitePageConfig = [[MAVERemoteConfigurationContactsInvitePage alloc] init];
+    invitePageConfig.smsInviteSendMethod = MAVESMSInviteSendMethodClientSideGroup;
+    id maveMock = OCMPartialMock([MaveSDK sharedInstance]);
+    MAVERemoteConfiguration *remoteConfig = [[MAVERemoteConfiguration alloc] init];
+    remoteConfig.contactsInvitePage = invitePageConfig;
+    OCMStub([maveMock remoteConfiguration]).andReturn(remoteConfig);
+
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
+    OCMStub([chooserMock isServerSideSMSAllowed]).andReturn(NO);
+    OCMExpect([chooserMock isAnyContactsInvitePageAllowed]).andReturn(YES);
+
+    MAVEContactsInvitePageV3ViewController *vc = [chooser createContactsInvitePageV3IfAllowed];
+
+    XCTAssertNotNil(vc);
+    XCTAssertEqual(vc.inviteSendMethod, MAVESMSInviteSendMethodClientSideGroup);
+    OCMVerifyAll(chooserMock);
+}
+
+- (void)testCreateContactsInvitePageV3WhenContactsInvitePageNotAllowed {
+    MAVERemoteConfigurationContactsInvitePage *invitePageConfig = [[MAVERemoteConfigurationContactsInvitePage alloc] init];
+    invitePageConfig.smsInviteSendMethod = MAVESMSInviteSendMethodClientSideGroup;
+    id maveMock = OCMPartialMock([MaveSDK sharedInstance]);
+    MAVERemoteConfiguration *remoteConfig = [[MAVERemoteConfiguration alloc] init];
+    remoteConfig.contactsInvitePage = invitePageConfig;
+    OCMStub([maveMock remoteConfiguration]).andReturn(remoteConfig);
+
+    MAVEInvitePageChooser *chooser = [[MAVEInvitePageChooser alloc] init];
+    id chooserMock = OCMPartialMock(chooser);
+    OCMStub([chooserMock isServerSideSMSAllowed]).andReturn(NO);
+    OCMExpect([chooserMock isAnyContactsInvitePageAllowed]).andReturn(NO);
+
+    MAVEContactsInvitePageV3ViewController *vc = [chooser createContactsInvitePageV3IfAllowed];
+
+    XCTAssertNil(vc);
+    OCMVerifyAll(chooserMock);
+}
+
+
+
 - (void)testChooseAndCreateUsingSharePagePrimary {
     id maveMock = OCMPartialMock([MaveSDK sharedInstance]);
     MAVERemoteConfiguration *remoteConfig = [[MAVERemoteConfiguration alloc] initWithDictionary:[MAVERemoteConfiguration defaultJSONData]];

--- a/MaveSDKTests/Controllers/MAVESharerTests.m
+++ b/MaveSDKTests/Controllers/MAVESharerTests.m
@@ -227,7 +227,17 @@
 }
 
 - (void)testComposeClientEmailInviteIfRecipientsNil {
+    id emailComposeVCMock = OCMClassMock([MFMailComposeViewController class]);
+    id builderMock = OCMClassMock([MAVESharerViewControllerBuilder class]);
+    OCMExpect([builderMock MFMailComposeViewController]).andReturn(emailComposeVCMock);
+    // should not set the recipients if nil
+    [[emailComposeVCMock reject] setBccRecipients:[OCMArg any]];
 
+    UIViewController *vc = [MAVESharer composeClientEmailInviteToRecipientEmails:nil withCompletionBlock:[OCMArg any]];
+
+    XCTAssertNotNil(vc);
+    OCMVerifyAll(emailComposeVCMock);
+    OCMVerifyAll(builderMock);
 }
 
 - (void)testComposeClientEmailInviteReturnsNilIfCantSendEmail {

--- a/MaveSDKTests/Controllers/MAVESharerTests.m
+++ b/MaveSDKTests/Controllers/MAVESharerTests.m
@@ -130,8 +130,15 @@
     id builderMock = OCMClassMock([MAVESharerViewControllerBuilder class]);
     [[builderMock reject] sharerInstanceRetained];
 
-    UIViewController *vc = [MAVESharer composeClientSMSInviteToRecipientPhones:nil completionBlock:nil];
+    __block MessageComposeResult returnedComposeResult;
+    __block BOOL wasCalled = NO;
+    UIViewController *vc = [MAVESharer composeClientSMSInviteToRecipientPhones:nil completionBlock:^(MFMessageComposeViewController *controller, MessageComposeResult composeResult) {
+        returnedComposeResult = composeResult;
+        wasCalled = YES;
+    }];
     XCTAssertNil(vc);
+    XCTAssertTrue(wasCalled);
+    XCTAssertEqual(returnedComposeResult, MessageComposeResultFailed);
     OCMVerifyAll(builderMock);
 }
 
@@ -217,6 +224,23 @@
     OCMVerifyAll(builderMock);
 }
 
+- (void)testComposeClientEmailInviteReturnsNilIfCantSendEmail {
+    id mailComposeVCMock = OCMClassMock([MFMailComposeViewController class]);
+    OCMExpect([mailComposeVCMock canSendMail]).andReturn(NO);
+    id builderMock = OCMClassMock([MAVESharerViewControllerBuilder class]);
+    [[builderMock reject] sharerInstanceRetained];
+
+    __block MFMailComposeResult returnedComposeResult;
+    __block BOOL wasCalled = NO;
+    UIViewController *vc = [MAVESharer composeClientEmailWithCompletionBlock:^(MFMailComposeViewController *controller, MFMailComposeResult result) {
+        returnedComposeResult = result;
+        wasCalled = YES;
+    }];
+    XCTAssertNil(vc);
+    XCTAssertTrue(wasCalled);
+    XCTAssertEqual(returnedComposeResult, MFMailComposeResultFailed);
+    OCMVerifyAll(builderMock);
+}
 
 - (void)testComposeClientEmailCompletionBlockSuccess {
     MAVESharer *sharer = [[MAVESharer alloc] initAndRetainSelf];

--- a/MaveSDKTests/Controllers/MAVESharerTests.m
+++ b/MaveSDKTests/Controllers/MAVESharerTests.m
@@ -204,16 +204,18 @@
     OCMExpect([emailComposeVCMock setMailComposeDelegate:sharerInstance]);
 
     // email message subject and body
+    NSArray *recipients = @[@"foo@example.com", @"bar@example.com"];
     NSString *expectedMessageSubject = sharerInstance.remoteConfiguration.clientEmail.subject;
     XCTAssertGreaterThan([expectedMessageSubject length], 0);
     OCMExpect([emailComposeVCMock setSubject:expectedMessageSubject]);
     NSString *expectedMessageBody = [MAVESharer shareCopyFromCopy:sharerInstance.remoteConfiguration.clientEmail.body andLinkWithSubRouteLetter:@"e"];
     XCTAssertGreaterThan([expectedMessageBody length], 0);
     OCMExpect([emailComposeVCMock setMessageBody:expectedMessageBody isHTML:NO]);
+    OCMExpect([emailComposeVCMock setBccRecipients:recipients]);
 
     void (^myCompletionBlock)(MFMailComposeViewController *controller, MFMailComposeResult result) = ^void(MFMailComposeViewController *controller, MFMailComposeResult result) {};
 
-    UIViewController *vc = [MAVESharer composeClientEmailWithCompletionBlock:myCompletionBlock];
+    UIViewController *vc = [MAVESharer composeClientEmailInviteToRecipientEmails:recipients withCompletionBlock:myCompletionBlock];
 
     XCTAssertNotNil(vc);
     XCTAssertEqualObjects(vc, emailComposeVCMock);
@@ -224,6 +226,10 @@
     OCMVerifyAll(builderMock);
 }
 
+- (void)testComposeClientEmailInviteIfRecipientsNil {
+
+}
+
 - (void)testComposeClientEmailInviteReturnsNilIfCantSendEmail {
     id mailComposeVCMock = OCMClassMock([MFMailComposeViewController class]);
     OCMExpect([mailComposeVCMock canSendMail]).andReturn(NO);
@@ -232,7 +238,7 @@
 
     __block MFMailComposeResult returnedComposeResult;
     __block BOOL wasCalled = NO;
-    UIViewController *vc = [MAVESharer composeClientEmailWithCompletionBlock:^(MFMailComposeViewController *controller, MFMailComposeResult result) {
+    UIViewController *vc = [MAVESharer composeClientEmailInviteToRecipientEmails:nil withCompletionBlock:^(MFMailComposeViewController *controller, MFMailComposeResult result) {
         returnedComposeResult = result;
         wasCalled = YES;
     }];

--- a/MaveSDKTests/Views/MAVEShareButtonsViewTests.m
+++ b/MaveSDKTests/Views/MAVEShareButtonsViewTests.m
@@ -150,7 +150,7 @@
     MAVEShareButtonsView *view = [[MAVEShareButtonsView alloc] init];
     id mock = OCMPartialMock(view);
     id sharerMock = OCMClassMock([MAVESharer class]);
-    OCMExpect([sharerMock composeClientEmailWithCompletionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
+    OCMExpect([sharerMock composeClientEmailInviteToRecipientEmails:nil withCompletionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
         void (^completionBlock)(MFMailComposeViewController *controller, MFMailComposeResult result) = obj;
         completionBlock(nil, MFMailComposeResultSent);
         return YES;
@@ -172,7 +172,7 @@
     MAVEShareButtonsView *view = [[MAVEShareButtonsView alloc] init];
     id mock = OCMPartialMock(view);
     id sharerMock = OCMClassMock([MAVESharer class]);
-    OCMExpect([sharerMock composeClientEmailWithCompletionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
+    OCMExpect([sharerMock composeClientEmailInviteToRecipientEmails:nil withCompletionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
         void (^completionBlock)(MFMailComposeViewController *controller, MFMailComposeResult result) = obj;
         completionBlock(nil, MFMailComposeResultCancelled);
         return YES;

--- a/Podfile
+++ b/Podfile
@@ -8,5 +8,5 @@ end
 
 target "MaveSDKTests" do
   pod "Gizou"
-  pod "OCMock", "~>3.1.1"
+  pod "OCMock", "~>3.1.2"
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,7 +21,7 @@ DEPENDENCIES:
   - Gizou
   - libPhoneNumber-iOS (= 0.8.3)
   - MMDrawerController (~> 0.6.0)
-  - OCMock
+  - OCMock (~> 3.1.2)
 
 SPEC CHECKSUMS:
   CCTemplate: f00efa85dad31e12b8a766b8e8198eb772c71c4f
@@ -30,4 +30,4 @@ SPEC CHECKSUMS:
   MMDrawerController: e3a54a5570388463ad3b36975251575b50c4e1a0
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
 
-COCOAPODS: 0.36.0
+COCOAPODS: 0.38.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,7 +21,7 @@ DEPENDENCIES:
   - Gizou
   - libPhoneNumber-iOS (= 0.8.3)
   - MMDrawerController (~> 0.6.0)
-  - OCMock (~> 3.1.1)
+  - OCMock
 
 SPEC CHECKSUMS:
   CCTemplate: f00efa85dad31e12b8a766b8e8198eb772c71c4f


### PR DESCRIPTION
Adds a flag (server-configurable) to send invites from the client rather than server-side. Works on invite page v3.

The way it works is you select contacts (with their individual phone/ email addresses) like normal, then hit the send button. Then it loads a group SMS with all the phones you've selected, after which it loads the email client with an email composed that BCC's all the emails you've selected. In the future we may tweak the variations of this (e.g. option to have the SMS dialog compose the SMS to just one person at a time and pop up that dialog multiple times sequentially as you send them).