### PR TITLE
Add public api to invite suggested

### DIFF
--- a/MaveSDK.xcodeproj/project.pbxproj
+++ b/MaveSDK.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		0C58FE001A657A8C007F8F12 /* MAVERemoteConfigurationCustomSharePageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C58FDFF1A657A8C007F8F12 /* MAVERemoteConfigurationCustomSharePageTests.m */; };
 		0C58FE031A66D734007F8F12 /* MAVERemoteConfigurationServerSMS.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C58FE021A66D734007F8F12 /* MAVERemoteConfigurationServerSMS.m */; };
 		0C58FE051A66D977007F8F12 /* MAVERemoteConfigurationServerSMSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C58FE041A66D977007F8F12 /* MAVERemoteConfigurationServerSMSTests.m */; };
+		0C6B42B21B6BC69A00ED6B99 /* MAVEInviteSender.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C6B42B11B6BC69A00ED6B99 /* MAVEInviteSender.m */; };
+		0C6B42B41B6BC6AB00ED6B99 /* MAVEInviteSenderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C6B42B31B6BC6AB00ED6B99 /* MAVEInviteSenderTests.m */; };
 		0C6D92A81A72B78300B65B82 /* MAVEABSyncManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C6D92A71A72B78300B65B82 /* MAVEABSyncManagerTests.m */; };
 		0C6D92AA1A72BA0F00B65B82 /* libz.1.1.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C6D92A91A72BA0F00B65B82 /* libz.1.1.3.dylib */; };
 		0C6D92AD1A72BE4A00B65B82 /* MAVECompressionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C6D92AC1A72BE4A00B65B82 /* MAVECompressionUtils.m */; };
@@ -448,6 +450,9 @@
 		0C58FE011A66D734007F8F12 /* MAVERemoteConfigurationServerSMS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MAVERemoteConfigurationServerSMS.h; sourceTree = "<group>"; };
 		0C58FE021A66D734007F8F12 /* MAVERemoteConfigurationServerSMS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVERemoteConfigurationServerSMS.m; sourceTree = "<group>"; };
 		0C58FE041A66D977007F8F12 /* MAVERemoteConfigurationServerSMSTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVERemoteConfigurationServerSMSTests.m; sourceTree = "<group>"; };
+		0C6B42B01B6BC69A00ED6B99 /* MAVEInviteSender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MAVEInviteSender.h; sourceTree = "<group>"; };
+		0C6B42B11B6BC69A00ED6B99 /* MAVEInviteSender.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVEInviteSender.m; sourceTree = "<group>"; };
+		0C6B42B31B6BC6AB00ED6B99 /* MAVEInviteSenderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MAVEInviteSenderTests.m; sourceTree = "<group>"; };
 		0C6D92A71A72B78300B65B82 /* MAVEABSyncManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MAVEABSyncManagerTests.m; path = ../Models/MAVEABSyncManagerTests.m; sourceTree = "<group>"; };
 		0C6D92A91A72BA0F00B65B82 /* libz.1.1.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.1.3.dylib; path = usr/lib/libz.1.1.3.dylib; sourceTree = SDKROOT; };
 		0C6D92AB1A72BE4A00B65B82 /* MAVECompressionUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MAVECompressionUtils.h; sourceTree = "<group>"; };
@@ -1199,6 +1204,8 @@
 				0C29BC661A5EC96600C27DA5 /* MAVECustomSharePageViewController.m */,
 				0C03BE651AAA30090008BCC0 /* MAVESharer.h */,
 				0C03BE661AAA30090008BCC0 /* MAVESharer.m */,
+				0C6B42B01B6BC69A00ED6B99 /* MAVEInviteSender.h */,
+				0C6B42B11B6BC69A00ED6B99 /* MAVEInviteSender.m */,
 				0C1BE8641AD59D5F009FA742 /* MAVEContactsInvitePageV2ViewController.h */,
 				0C1BE8651AD59D5F009FA742 /* MAVEContactsInvitePageV2ViewController.m */,
 				0C435C6F1B0E4E2E005B11AF /* MAVEContactsInvitePageV3ViewController.h */,
@@ -1294,6 +1301,7 @@
 				0C29BC271A544EF000C27DA5 /* MAVEABPermissionPromptHandlerTest.m */,
 				0CCC92BF1A60090D008CB888 /* MAVECustomSharePageViewControllerTests.m */,
 				0C03BE681AAA33CE0008BCC0 /* MAVESharerTests.m */,
+				0C6B42B31B6BC6AB00ED6B99 /* MAVEInviteSenderTests.m */,
 				0C25A3F21AD6E3420031D163 /* MAVEContactsInvitePageV2ViewControllerTests.m */,
 				0CE36EBF1B1763D5005BF445 /* MAVEContactsInvitePageV3ViewControllerTests.m */,
 				0C462F5B1B5EC08C003A290C /* MAVEContactsInvitePageV3SendClientSideInvitesTests.m */,
@@ -1634,6 +1642,7 @@
 				0C29BC2E1A56FF6D00C27DA5 /* MAVEAPIInterface.m in Sources */,
 				C02927FA19E82D03006AEE43 /* MAVEInvitePageViewController.m in Sources */,
 				0C29BC671A5EC96600C27DA5 /* MAVECustomSharePageViewController.m in Sources */,
+				0C6B42B21B6BC69A00ED6B99 /* MAVEInviteSender.m in Sources */,
 				0CCC92B71A5F28E1008CB888 /* MAVEBuiltinUIElementUtils.m in Sources */,
 				0C435C791B0E5F6A005B11AF /* MAVEContactsInvitePageV3Cell.m in Sources */,
 				0C58FDFE1A6578D3007F8F12 /* MAVERemoteConfigurationCustomSharePage.m in Sources */,
@@ -1770,6 +1779,7 @@
 				0CFE94891AAE3A5700320FF3 /* MAVERemoteConfigurationInvitePageChoiceTests.m in Sources */,
 				0C775E301A9FB6F30028D687 /* MAVEReferringDataTests.m in Sources */,
 				0C0996F81A793B4F003B82AA /* MAVEMerkleTreeUtilsTests.m in Sources */,
+				0C6B42B41B6BC6AB00ED6B99 /* MAVEInviteSenderTests.m in Sources */,
 				0C0996E71A76F302003B82AA /* MAVEMerkleTreeDataEnumeratorTests.m in Sources */,
 				0C7200741A19A87900E12B91 /* MAVEInvitePageBottomActionContainerViewTests.m in Sources */,
 				0CABFAF01B447222007E09DE /* MAVEContactsInvitePageSearchManagerTests.m in Sources */,

--- a/MaveSDK/Controllers/MAVEInviteSender.h
+++ b/MaveSDK/Controllers/MAVEInviteSender.h
@@ -1,0 +1,15 @@
+//
+//  MAVEInviteSender.h
+//  MaveSDK
+//
+//  Created by Danny Cosson on 7/31/15.
+//
+//
+
+#import "MAVEABPerson.h"
+
+@interface MAVEInviteSender : NSObject
+
+- (void)invitePerson:(MAVEABPerson *)person withCompletionBlock:(void (^)(BOOL success))completionBlock;
+
+@end

--- a/MaveSDK/Controllers/MAVEInviteSender.m
+++ b/MaveSDK/Controllers/MAVEInviteSender.m
@@ -12,7 +12,7 @@
 @implementation MAVEInviteSender
 
 - (void)invitePerson:(MAVEABPerson *)person withCompletionBlock:(void (^)(BOOL success))completionBlock {
-    
+    [person selectBestContactIdentifierIfNoneSelected];
     MaveSDK *mave = [MaveSDK sharedInstance];
     NSArray *recipients = @[person];
     [mave.APIInterface sendInvitesToRecipients:recipients smsCopy:mave.defaultSMSMessageText senderUserID:mave.userData.userID inviteLinkDestinationURL:mave.userData.inviteLinkDestinationURL wrapInviteLink:mave.userData.wrapInviteLink customData:mave.userData.customData completionBlock:^(NSError *error, NSDictionary *responseData) {

--- a/MaveSDK/Controllers/MAVEInviteSender.m
+++ b/MaveSDK/Controllers/MAVEInviteSender.m
@@ -1,0 +1,27 @@
+//
+//  MAVEInviteSender.m
+//  MaveSDK
+//
+//  Created by Danny Cosson on 7/31/15.
+//
+//
+
+#import "MAVEInviteSender.h"
+#import "MaveSDK.h"
+
+@implementation MAVEInviteSender
+
+- (void)invitePerson:(MAVEABPerson *)person withCompletionBlock:(void (^)(BOOL success))completionBlock {
+    
+    MaveSDK *mave = [MaveSDK sharedInstance];
+    NSArray *recipients = @[person];
+    [mave.APIInterface sendInvitesToRecipients:recipients smsCopy:mave.defaultSMSMessageText senderUserID:mave.userData.userID inviteLinkDestinationURL:mave.userData.inviteLinkDestinationURL wrapInviteLink:mave.userData.wrapInviteLink customData:mave.userData.customData completionBlock:^(NSError *error, NSDictionary *responseData) {
+        BOOL ok = YES;
+        if (error) {
+            ok = NO;
+        }
+        completionBlock(ok);
+    }];
+}
+
+@end

--- a/MaveSDK/MaveSDK.h
+++ b/MaveSDK/MaveSDK.h
@@ -17,6 +17,7 @@
 #import "MAVERemoteObjectBuilder.h"
 #import "MAVECustomSharePageViewController.h"
 #import "MAVEABSyncManager.h"
+#import "MAVEInviteSender.h"
 
 @interface MaveSDK : NSObject
 
@@ -25,6 +26,7 @@
 @property (nonatomic, strong) MAVEAPIInterface *APIInterface;
 @property (nonatomic, strong) MAVEABSyncManager *addressBookSyncManager;
 @property (nonatomic, strong) MAVEInvitePageChooser *invitePageChooser;
+@property (nonatomic, strong) MAVEInviteSender *inviteSender;
 @property (nonatomic, strong) MAVERemoteObjectBuilder *remoteConfigurationBuilder;
 @property (nonatomic, strong) MAVERemoteObjectBuilder *shareTokenBuilder;
 @property (nonatomic, strong) MAVERemoteObjectBuilder *suggestedInvitesBuilder;

--- a/MaveSDK/MaveSDK.m
+++ b/MaveSDK/MaveSDK.m
@@ -41,6 +41,7 @@
         NSString *apiBaseURL = [MAVEAPIBaseURL stringByAppendingString:MAVEAPIVersion];
         _APIInterface = [[MAVEAPIInterface alloc] initWithBaseURL:apiBaseURL];
         _addressBookSyncManager = [[MAVEABSyncManager alloc] init];
+        _inviteSender = [[MAVEInviteSender alloc] init];
     }
     return self;
 }

--- a/MaveSDK/Models/MAVEABPerson.h
+++ b/MaveSDK/Models/MAVEABPerson.h
@@ -94,7 +94,7 @@ typedef NS_ENUM(NSInteger, MAVEInviteSendingStatus) {
 - (NSArray *)selectedContactIdentifiers;
 
 - (BOOL)isAtLeastOneContactIdentifierSelected;
-- (void)selectTopContactIdentifierIfNoneSelected;
+- (void)selectBestContactIdentifierIfNoneSelected;
 
 + (NSString *)normalizePhoneNumber:(NSString *)phoneNumber;
 + (BOOL)looksLikeEmail:(NSString *)email;

--- a/MaveSDK/Models/MAVEABPerson.m
+++ b/MaveSDK/Models/MAVEABPerson.m
@@ -54,7 +54,7 @@
 
 - (void)setSelected:(BOOL)selected {
     if (selected) {
-        [self selectTopContactIdentifierIfNoneSelected];
+        [self selectBestContactIdentifierIfNoneSelected];
     } else {
         for (MAVEContactIdentifierBase *rec in self.allContactIdentifiers) {
             if (rec.selected) {
@@ -247,7 +247,7 @@
     return returnval;
 }
 
-- (void)selectTopContactIdentifierIfNoneSelected {
+- (void)selectBestContactIdentifierIfNoneSelected {
     if (![self isAtLeastOneContactIdentifierSelected]) {
         NSArray *rankedIdentifiers = [self rankedContactIdentifiersIncludeEmails:YES includePhones:YES];
         if ([rankedIdentifiers count] > 0) {

--- a/MaveSDKTests/Controllers/MAVEInviteSenderTests.m
+++ b/MaveSDKTests/Controllers/MAVEInviteSenderTests.m
@@ -44,6 +44,9 @@
     id apiInterfaceMock = OCMPartialMock([MaveSDK sharedInstance].APIInterface);
 
     MAVEABPerson *p0 = [[MAVEABPerson alloc] init];
+    MAVEContactEmail *email0 = [[MAVEContactEmail alloc] initWithValue:@"foo@example.com"];
+    MAVEContactEmail *email1 = [[MAVEContactEmail alloc] initWithValue:@"bar@example.com"];
+    p0.emailObjects = @[email0, email1];
     OCMExpect([apiInterfaceMock sendInvitesToRecipients:@[p0] smsCopy:[MaveSDK sharedInstance].defaultSMSMessageText senderUserID:@"123" inviteLinkDestinationURL:user.inviteLinkDestinationURL wrapInviteLink:NO customData:user.customData completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
         void (^completionBlock)(NSError *error, NSDictionary *responseData)  = obj;
         completionBlock(nil, nil);
@@ -58,6 +61,9 @@
 
     XCTAssertTrue(sentOK);
     OCMVerifyAll(apiInterfaceMock);
+    // Since neither contact identifier (email) was already marked as selected
+    // this method should have marked the first one as selected
+    XCTAssertTrue(email0.selected);
 }
 
 

--- a/MaveSDKTests/Controllers/MAVEInviteSenderTests.m
+++ b/MaveSDKTests/Controllers/MAVEInviteSenderTests.m
@@ -1,0 +1,65 @@
+//
+//  MAVEInviteSenderTests.m
+//  MaveSDK
+//
+//  Created by Danny Cosson on 7/31/15.
+//
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+
+#import "MAVEInviteSender.h"
+#import "MaveSDK.h"
+#import "MAVEABPerson.h"
+
+@interface MaveSDK(Testing)
++ (void)resetSharedInstanceForTesting;
+@end
+
+@interface MAVEInviteSenderTests : XCTestCase
+
+@end
+
+@implementation MAVEInviteSenderTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testSendInviteToPerson {
+    [MaveSDK resetSharedInstanceForTesting];
+    [MaveSDK setupSharedInstanceWithApplicationID:@"foo234"];
+    MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"123" firstName:@"Foo" lastName:@"Example"];
+    user.inviteLinkDestinationURL = @"http://example.com/invite";
+    user.wrapInviteLink = NO;
+    user.customData = @{@"value": @"foo"};
+    [[MaveSDK sharedInstance] identifyUser:user];
+    id apiInterfaceMock = OCMPartialMock([MaveSDK sharedInstance].APIInterface);
+
+    MAVEABPerson *p0 = [[MAVEABPerson alloc] init];
+    OCMExpect([apiInterfaceMock sendInvitesToRecipients:@[p0] smsCopy:[MaveSDK sharedInstance].defaultSMSMessageText senderUserID:@"123" inviteLinkDestinationURL:user.inviteLinkDestinationURL wrapInviteLink:NO customData:user.customData completionBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
+        void (^completionBlock)(NSError *error, NSDictionary *responseData)  = obj;
+        completionBlock(nil, nil);
+        return YES;
+    }]]);
+
+    MAVEInviteSender *sender = [[MAVEInviteSender alloc] init];
+    __block BOOL sentOK = NO;
+    [sender invitePerson:p0 withCompletionBlock:^(BOOL success) {
+        sentOK = success;
+    }];
+
+    XCTAssertTrue(sentOK);
+    OCMVerifyAll(apiInterfaceMock);
+}
+
+
+
+@end

--- a/MaveSDKTests/MaveSDKTests.m
+++ b/MaveSDKTests/MaveSDKTests.m
@@ -59,6 +59,7 @@
     XCTAssertNotNil(mave.remoteConfigurationBuilder);
     XCTAssertNil(mave.shareTokenBuilder);
     XCTAssertNotNil(mave.addressBookSyncManager);
+    XCTAssertNotNil(mave.inviteSender);
     XCTAssertNotNil(mave.suggestedInvitesBuilder);
     XCTAssertNotNil(mave.referringDataBuilder);
     XCTAssertFalse(mave.debug);

--- a/MaveSDKTests/Models/MAVEABPersonTests.m
+++ b/MaveSDKTests/Models/MAVEABPersonTests.m
@@ -445,7 +445,7 @@
     XCTAssertEqual([[p1 rankedContactIdentifiersIncludeEmails:NO includePhones:NO] count], 0);
 }
 
-- (void)testSelectTopContactIdentifierIfNoneSelected {
+- (void)testSelectBestContactIdentifierIfNoneSelected {
     MAVEABPerson *p1 = [[MAVEABPerson alloc] init];
     MAVEContactPhoneNumber *phone = [[MAVEContactPhoneNumber alloc] initWithValue:@"+18085551234" andLabel:@"iPhone"];
     MAVEContactEmail *email = [[MAVEContactEmail alloc] initWithValue:@"foo@example.com"];
@@ -453,13 +453,13 @@
     p1.emailObjects = @[email];
     email.selected = YES;
     // does nothing if one is already selected
-    [p1 selectTopContactIdentifierIfNoneSelected];
+    [p1 selectBestContactIdentifierIfNoneSelected];
     XCTAssertFalse(phone.selected);
     XCTAssertTrue(email.selected);
 
     phone.selected = NO;
     email.selected = NO;
-    [p1 selectTopContactIdentifierIfNoneSelected];
+    [p1 selectBestContactIdentifierIfNoneSelected];
     XCTAssertTrue(phone.selected);
     XCTAssertFalse(email.selected);
 }
@@ -467,7 +467,7 @@
 - (void)testContactIdentifierSelectedMethodsDontCrashWhenEmpty {
     MAVEABPerson *p1 = [[MAVEABPerson alloc] init];
     XCTAssertFalse([p1 isAtLeastOneContactIdentifierSelected]);
-    [p1 selectTopContactIdentifierIfNoneSelected];
+    [p1 selectBestContactIdentifierIfNoneSelected];
     XCTAssertFalse([p1 isAtLeastOneContactIdentifierSelected]);
 }
 


### PR DESCRIPTION
Add a method apps can use after getting suggested invites to send invites to those people.

If no phone or email belonging to the person is already marked as `selected`, this method will select the best one to send to.