### PR TITLE
{{ link }} variable for message templates

### DIFF
--- a/MaveSDK/Controllers/MAVESharer.h
+++ b/MaveSDK/Controllers/MAVESharer.h
@@ -46,6 +46,8 @@ extern NSString * const MAVESharePageShareTypeClipboard;
 //
 - (MAVERemoteConfiguration *)remoteConfiguration;
 + (NSString *)shareToken;
++ (NSString *)clientSMSMessageText;
+
 + (NSString *)shareCopyFromCopy:(NSString *)shareCopy
       andLinkWithSubRouteLetter:(NSString *)letter;
 

--- a/MaveSDK/Controllers/MAVESharer.h
+++ b/MaveSDK/Controllers/MAVESharer.h
@@ -46,8 +46,6 @@ extern NSString * const MAVESharePageShareTypeClipboard;
 //
 - (MAVERemoteConfiguration *)remoteConfiguration;
 + (NSString *)shareToken;
-+ (NSString *)clientSMSMessageText;
-
 + (NSString *)shareCopyFromCopy:(NSString *)shareCopy
       andLinkWithSubRouteLetter:(NSString *)letter;
 

--- a/MaveSDK/Controllers/MAVESharer.m
+++ b/MaveSDK/Controllers/MAVESharer.m
@@ -48,10 +48,9 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
     ownInstance.completionBlockClientSMS = completionBlock;
 
     MFMessageComposeViewController *composeVC = [MAVESharerViewControllerBuilder MFMessageComposeViewController];
-    NSString *message = [self shareCopyFromCopy:ownInstance.remoteConfiguration.clientSMS.text andLinkWithSubRouteLetter:@"s"];
 
     composeVC.messageComposeDelegate = ownInstance;
-    composeVC.body = message;
+    composeVC.body = ownInstance.remoteConfiguration.clientSMS.text;
 
     if (recipientPhones && [recipientPhones count] > 0) {
         composeVC.recipients = recipientPhones;

--- a/MaveSDK/Controllers/MAVESharer.m
+++ b/MaveSDK/Controllers/MAVESharer.m
@@ -177,9 +177,7 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
     ownInstance.completionBlockTwitterNativeShare = completionBlock;
 
     SLComposeViewController *composeVC = [MAVESharerViewControllerBuilder SLComposeViewControllerForTwitter];
-    NSString *message = [self shareCopyFromCopy:ownInstance.remoteConfiguration.twitterShare.text
-                                   andLinkWithSubRouteLetter:@"t"];
-    [composeVC setInitialText:message];
+    [composeVC setInitialText:ownInstance.remoteConfiguration.twitterShare.text];
     __weak SLComposeViewController *weakComposeVC = composeVC;
     composeVC.completionHandler = ^(SLComposeViewControllerResult result) {
         [ownInstance twitterNativeShareController:weakComposeVC didFinishWithResult:result];
@@ -206,11 +204,8 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
 
 + (void)composePasteboardShare {
     MAVESharer *ownInstance = [MAVESharerViewControllerBuilder sharerInstanceRetained];
-    NSString *message = [self shareCopyFromCopy:ownInstance.remoteConfiguration.clipboardShare.text
-                                   andLinkWithSubRouteLetter:@"c"];
-
     UIPasteboard *pasteboard = [MAVESharerViewControllerBuilder UIPasteboard];
-    pasteboard.string = message;
+    pasteboard.string = ownInstance.remoteConfiguration.clipboardShare.text;
 
     [[MaveSDK sharedInstance].APIInterface trackShareActionClickWithShareType:MAVESharePageShareTypeClipboard];
 

--- a/MaveSDK/Controllers/MAVESharer.m
+++ b/MaveSDK/Controllers/MAVESharer.m
@@ -96,15 +96,14 @@ NSString * const MAVESharePageShareTypeClipboard = @"clipboard";
 
     MFMailComposeViewController *composeVC = [MAVESharerViewControllerBuilder MFMailComposeViewController];
     NSString *subject = ownInstance.remoteConfiguration.clientEmail.subject;
-    NSString *message = [self shareCopyFromCopy:ownInstance.remoteConfiguration.clientEmail.body
-                                   andLinkWithSubRouteLetter:@"e"];
+    NSString *body = ownInstance.remoteConfiguration.clientEmail.body;
 
     if ([recipients count] > 0) {
         composeVC.bccRecipients = recipients;
     }
     composeVC.mailComposeDelegate = ownInstance;
     composeVC.subject = subject;
-    [composeVC setMessageBody:message isHTML:NO];
+    [composeVC setMessageBody:body isHTML:NO];
 
     [[MaveSDK sharedInstance].APIInterface trackShareActionClickWithShareType:MAVESharePageShareTypeClientEmail];
     return composeVC;

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientEmail.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientEmail.m
@@ -9,6 +9,8 @@
 #import "MAVERemoteConfigurationClientEmail.h"
 #import "MAVEClientPropertyUtils.h"
 #import "MAVETemplatingUtils.h"
+#import "MaveSDK.h"
+#import "MAVESharer.h"
 
 NSString * const MAVERemoteConfigKeyClientEmailTemplate = @"template";
 NSString * const MAVERemoteConfigKeyClientEmailTemplateID = @"template_id";
@@ -41,11 +43,20 @@ NSString * const MAVERemoteConfigKeyClientEmailBody = @"body_template";
 }
 
 - (NSString *)subject {
-    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.subjectTemplate];
+    // NB: don't append link to subject if none b/c subject doesn't need link,
+    // but still render template with it in case anyone tries to use it
+    // if we generate link, email should use an "e" to designate
+    NSString *link = [MAVESharer shareLinkWithSubRouteLetter:@"e"];
+    MAVEUserData *user = [MaveSDK sharedInstance].userData;
+    return [MAVETemplatingUtils interpolateTemplateString:self.subjectTemplate withUser:user link:link];
 }
 
 - (NSString *)body {
-    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.bodyTemplate];
+    NSString *templateWithLink = [MAVETemplatingUtils appendLinkVariableToTemplateStringIfNeeded:self.bodyTemplate];
+    // if we generate link, email should use an "e" to designate
+    NSString *link = [MAVESharer shareLinkWithSubRouteLetter:@"e"];
+    MAVEUserData *user = [MaveSDK sharedInstance].userData;
+    return [MAVETemplatingUtils interpolateTemplateString:templateWithLink withUser:user link:link];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientSMS.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClientSMS.m
@@ -7,6 +7,7 @@
 //
 
 #import "MAVERemoteConfigurationClientSMS.h"
+#import "MaveSDK.h"
 #import "MAVEClientPropertyUtils.h"
 #import "MAVETemplatingUtils.h"
 
@@ -38,7 +39,11 @@ NSString * const MAVERemoteConfigKeyClientSMSCopyTemplate = @"copy_template";
 }
 
 - (NSString *)text {
-    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.textTemplate];
+    NSString *templateWithLink = [MAVETemplatingUtils appendLinkVariableToTemplateStringIfNeeded:self.textTemplate];
+    // if we generate link, sms should use an "s" to designate
+    NSString *link = [MAVESharer shareLinkWithSubRouteLetter:@"s"];
+    MAVEUserData *user = [MaveSDK sharedInstance].userData;
+    return [MAVETemplatingUtils interpolateTemplateString:templateWithLink withUser:user link:link];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClipboardShare.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationClipboardShare.m
@@ -9,6 +9,8 @@
 #import "MAVERemoteConfigurationClipboardShare.h"
 #import "MAVEClientPropertyUtils.h"
 #import "MAVETemplatingUtils.h"
+#import "MaveSDK.h"
+#import "MAVESharer.h"
 
 NSString * const MAVERemoteConfigKeyClipboardShareTemplate = @"template";
 NSString * const MAVERemoteConfigKeyClipboardShareTemplateID = @"template_id";
@@ -37,7 +39,11 @@ NSString * const MAVERemoteConfigKeyClipboardShareCopy = @"copy_template";
 }
 
 - (NSString *)text {
-    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.textTemplate];
+    NSString *templateWithLink = [MAVETemplatingUtils appendLinkVariableToTemplateStringIfNeeded:self.textTemplate];
+    // if we generate link, clipboard should use a "c" to designate
+    NSString *link = [MAVESharer shareLinkWithSubRouteLetter:@"c"];
+    MAVEUserData *user = [MaveSDK sharedInstance].userData;
+    return [MAVETemplatingUtils interpolateTemplateString:templateWithLink withUser:user link:link];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationFacebookShare.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationFacebookShare.m
@@ -9,6 +9,7 @@
 #import "MAVERemoteConfigurationFacebookShare.h"
 #import "MAVEClientPropertyUtils.h"
 #import "MAVETemplatingUtils.h"
+#import "MaveSDK.h"
 
 NSString * const MAVERemoteConfigKeyFacebookShareTemplate = @"template";
 NSString * const MAVERemoteConfigKeyFacebookShareTemplateID = @"template_id";
@@ -36,7 +37,10 @@ NSString * const MAVERemoteConfigKeyFacebookShareCopy = @"initial_text_template"
 }
 
 - (NSString *)text {
-    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.textTemplate];
+    // don't need to interpolate the {{ link }} variable bc the link gets
+    // set separately as metadata on the FB post
+    MAVEUserData *user = [MaveSDK sharedInstance].userData;
+    return [MAVETemplatingUtils interpolateTemplateString:self.textTemplate withUser:user link:nil];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMS.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMS.m
@@ -9,6 +9,7 @@
 #import "MAVERemoteConfigurationServerSMS.h"
 #import "MAVEClientPropertyUtils.h"
 #import "MAVETemplatingUtils.h"
+#import "MaveSDK.h"
 
 NSString * const MAVERemoteConfigKeyServerSMSTemplate = @"template";
 NSString * const MAVERemoteConfigKeyServerSMSTemplateID = @"template_id";
@@ -39,7 +40,16 @@ NSString * const MAVERemoteConfigKeyServerSMSCopy = @"copy_template";
 
 // Returns the sms copy with template values filled in
 - (NSString *)text {
-    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.textTemplate];
+    // fill in link var with itself, to let the it pass through since the
+    // link needs to be filled in on the server for server-side sms.
+    //
+    // Note we don't append {{ link }} to the end, if there's no {{ link }}
+    // explicitly in the template it doesn't get put in. This lets the
+    // user-editable message invite pages (V1 & V2) continue working by
+    // just not using that template variable. The server will append a
+    // link if the text it receives has no {{ link }} var.
+    MAVEUserData *user = [MaveSDK sharedInstance].userData;
+    return [MAVETemplatingUtils interpolateTemplateString:self.textTemplate withUser:user link:@"{{ link }}"];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationTwitterShare.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationTwitterShare.m
@@ -9,6 +9,8 @@
 #import "MAVERemoteConfigurationTwitterShare.h"
 #import "MAVEClientPropertyUtils.h"
 #import "MAVETemplatingUtils.h"
+#import "MaveSDK.h"
+#import "MAVESharer.h"
 
 NSString * const MAVERemoteConfigKeyTwitterShareTemplate = @"template";
 NSString * const MAVERemoteConfigKeyTwitterShareTemplateID = @"template_id";
@@ -37,7 +39,11 @@ NSString * const MAVERemoteConfigKeyTwitterShareCopy = @"copy_template";
 }
 
 - (NSString *)text {
-    return [MAVETemplatingUtils interpolateWithSingletonDataTemplateString:self.textTemplate];
+    NSString *templateWithLink = [MAVETemplatingUtils appendLinkVariableToTemplateStringIfNeeded:self.textTemplate];
+    // if we generate link, twitter should use a "t" to designate
+    NSString *link = [MAVESharer shareLinkWithSubRouteLetter:@"t"];
+    MAVEUserData *user = [MaveSDK sharedInstance].userData;
+    return [MAVETemplatingUtils interpolateTemplateString:templateWithLink withUser:user link:link];
 }
 
 + (NSDictionary *)defaultJSONData {

--- a/MaveSDK/Utils/MAVETemplatingUtils.h
+++ b/MaveSDK/Utils/MAVETemplatingUtils.h
@@ -16,10 +16,10 @@
 + (NSString *)convertValueToString:(id)value;
 
 // Helper method to interpolate the template string using the current context.
-// Available fields in template are user.* and customData.*
+// Available fields in template are user.* and customData.*, but the way we
+// pass the values in customData is a property of MAVEUserData.
 + (NSString *)interpolateTemplateString:(NSString *)templateString
-                               withUser:(MAVEUserData *)user
-                             customData:(NSDictionary *)customData;
+                               withUser:(MAVEUserData *)user;
 
 + (NSString *)appendLinkVariableToTemplateStringIfNeeded:(NSString *)templateString;
 

--- a/MaveSDK/Utils/MAVETemplatingUtils.h
+++ b/MaveSDK/Utils/MAVETemplatingUtils.h
@@ -21,6 +21,8 @@
                                withUser:(MAVEUserData *)user
                              customData:(NSDictionary *)customData;
 
++ (NSString *)appendLinkVariableToTemplateStringIfNeeded:(NSString *)templateString;
+
 + (NSString *)interpolateWithSingletonDataTemplateString:(NSString *)templateString;
 
 @end

--- a/MaveSDK/Utils/MAVETemplatingUtils.h
+++ b/MaveSDK/Utils/MAVETemplatingUtils.h
@@ -19,7 +19,8 @@
 // Available fields in template are user.* and customData.*, but the way we
 // pass the values in customData is a property of MAVEUserData.
 + (NSString *)interpolateTemplateString:(NSString *)templateString
-                               withUser:(MAVEUserData *)user;
+                               withUser:(MAVEUserData *)user
+                                   link:(NSString *)link;
 
 + (NSString *)appendLinkVariableToTemplateStringIfNeeded:(NSString *)templateString;
 

--- a/MaveSDK/Utils/MAVETemplatingUtils.m
+++ b/MaveSDK/Utils/MAVETemplatingUtils.m
@@ -67,7 +67,11 @@
     // a template variable, e.g. allowing both {{var}} and {{   var   }}.
     NSString *output = templateString;
     NSString *_tmp = [templateString templateFromDict:@{@"link": LINKVAL}];
-    if (![_tmp containsString:LINKVAL]) {
+    // ios7 doesnt have NSString containsString:
+    NSRange _foundInRange = [_tmp rangeOfString:LINKVAL];
+    BOOL containsLink = _foundInRange.length != 0;
+
+    if (!containsLink) {
         // template string has no link in it, so append one to the end, following a space
         NSString *lastLetter = [templateString substringFromIndex:[templateString length] - 1];
         if (![@[@" ", @"\n"] containsObject:lastLetter]) {

--- a/MaveSDK/Utils/MAVETemplatingUtils.m
+++ b/MaveSDK/Utils/MAVETemplatingUtils.m
@@ -53,6 +53,29 @@
     return nil;
 }
 
++ (NSString *)appendLinkVariableToTemplateStringIfNeeded:(NSString *)templateString {
+    NSString *LINKVAL = @"{{ link }}";
+    // Shouldn't get empty case, but just in case return only link
+    if ([templateString length] == 0) {
+        return LINKVAL;
+    }
+
+    // to check if template already contains link, actually fill it in with a value that
+    // won't exist in the string so we don't have to re-implement the logic to identify
+    // a template variable, e.g. allowing both {{var}} and {{   var   }}.
+    NSString *output = templateString;
+    NSString *_tmp = [templateString templateFromDict:@{@"link": LINKVAL}];
+    if (![_tmp containsString:LINKVAL]) {
+        // template string has no link in it, so append one to the end, following a space
+        NSString *lastLetter = [templateString substringFromIndex:[templateString length] - 1];
+        if (![@[@" ", @"\n"] containsObject:lastLetter]) {
+            output = [output stringByAppendingString:@" "];
+        }
+        output = [output stringByAppendingString:LINKVAL];
+    }
+    return output;
+}
+
 + (NSString *)interpolateWithSingletonDataTemplateString:(NSString *)templateString {
     MAVEUserData *user = [MaveSDK sharedInstance].userData;
     NSDictionary *customData = user.customData;

--- a/MaveSDK/Utils/MAVETemplatingUtils.m
+++ b/MaveSDK/Utils/MAVETemplatingUtils.m
@@ -12,7 +12,7 @@
 
 @implementation MAVETemplatingUtils
 
-+ (NSString *)interpolateTemplateString:(NSString *)templateString withUser:(MAVEUserData *)user customData:(NSDictionary *)customData {
++ (NSString *)interpolateTemplateString:(NSString *)templateString withUser:(MAVEUserData *)user {
 
     NSMutableDictionary *interpolationDict = [[NSMutableDictionary alloc] init];
 
@@ -22,6 +22,7 @@
     [interpolationDict setValue:user.lastName forKey:@"user.lastName"];
     [interpolationDict setValue:user.fullName forKey:@"user.fullName"];
     [interpolationDict setValue:user.promoCode forKey:@"user.promoCode"];
+    NSDictionary *customData = user.customData;
 
     NSString *namespacedKey, *key, *stringValue;
     for (key in customData) {
@@ -78,8 +79,7 @@
 
 + (NSString *)interpolateWithSingletonDataTemplateString:(NSString *)templateString {
     MAVEUserData *user = [MaveSDK sharedInstance].userData;
-    NSDictionary *customData = user.customData;
-    return [self interpolateTemplateString:templateString withUser:user customData:customData];
+    return [self interpolateTemplateString:templateString withUser:user];
 }
 
 

--- a/MaveSDK/Utils/MAVETemplatingUtils.m
+++ b/MaveSDK/Utils/MAVETemplatingUtils.m
@@ -12,7 +12,7 @@
 
 @implementation MAVETemplatingUtils
 
-+ (NSString *)interpolateTemplateString:(NSString *)templateString withUser:(MAVEUserData *)user {
++ (NSString *)interpolateTemplateString:(NSString *)templateString withUser:(MAVEUserData *)user link:(NSString *)link {
 
     NSMutableDictionary *interpolationDict = [[NSMutableDictionary alloc] init];
 
@@ -22,6 +22,7 @@
     [interpolationDict setValue:user.lastName forKey:@"user.lastName"];
     [interpolationDict setValue:user.fullName forKey:@"user.fullName"];
     [interpolationDict setValue:user.promoCode forKey:@"user.promoCode"];
+    [interpolationDict setValue:link forKey:@"link"];
     NSDictionary *customData = user.customData;
 
     NSString *namespacedKey, *key, *stringValue;
@@ -79,7 +80,7 @@
 
 + (NSString *)interpolateWithSingletonDataTemplateString:(NSString *)templateString {
     MAVEUserData *user = [MaveSDK sharedInstance].userData;
-    return [self interpolateTemplateString:templateString withUser:user];
+    return [self interpolateTemplateString:templateString withUser:user link:nil];
 }
 
 

--- a/MaveSDKTests/Controllers/MAVESharerTests.m
+++ b/MaveSDKTests/Controllers/MAVESharerTests.m
@@ -207,7 +207,7 @@
     NSString *expectedMessageSubject = sharerInstance.remoteConfiguration.clientEmail.subject;
     XCTAssertGreaterThan([expectedMessageSubject length], 0);
     OCMExpect([emailComposeVCMock setSubject:expectedMessageSubject]);
-    NSString *expectedMessageBody = [MAVESharer shareCopyFromCopy:sharerInstance.remoteConfiguration.clientEmail.body andLinkWithSubRouteLetter:@"e"];
+    NSString *expectedMessageBody = sharerInstance.remoteConfiguration.clientEmail.body;
     XCTAssertGreaterThan([expectedMessageBody length], 0);
     OCMExpect([emailComposeVCMock setMessageBody:expectedMessageBody isHTML:NO]);
     OCMExpect([emailComposeVCMock setBccRecipients:recipients]);

--- a/MaveSDKTests/Controllers/MAVESharerTests.m
+++ b/MaveSDKTests/Controllers/MAVESharerTests.m
@@ -61,7 +61,7 @@
     OCMExpect([builderMock sharerInstanceRetained]).andReturn(sharerInstance);
 
     // sms message text
-    NSString *expectedMessageText = [MAVESharer shareCopyFromCopy:sharerInstance.remoteConfiguration.clientSMS.text andLinkWithSubRouteLetter:@"s"];
+    NSString *expectedMessageText = sharerInstance.remoteConfiguration.clientSMS.text;
     XCTAssertGreaterThan([expectedMessageText length], 0);
     OCMExpect([messageComposeVCMock setBody:expectedMessageText]);
 
@@ -106,8 +106,7 @@
     [MaveSDK sharedInstance].userData.wrapInviteLink = NO;
     
     // sms message text
-    NSString *expectedMessageText = [sharerInstance.remoteConfiguration.clientSMS.text stringByAppendingString:@" http://example.com/unwrapped/link"];
-    OCMExpect([messageComposeVCMock setBody:expectedMessageText]);
+    OCMExpect([messageComposeVCMock setBody:sharerInstance.remoteConfiguration.clientSMS.text]);
     
     // sms recipient
     OCMExpect([messageComposeVCMock setRecipients:recipientPhones]);

--- a/MaveSDKTests/Controllers/MAVESharerTests.m
+++ b/MaveSDKTests/Controllers/MAVESharerTests.m
@@ -407,7 +407,7 @@
     OCMExpect([builderMock sharerInstanceRetained]).andReturn(sharerInstance);
 
     // expectations for content to pass to share view controller
-    NSString *expectedText = [MAVESharer shareCopyFromCopy:sharerInstance.remoteConfiguration.twitterShare.text andLinkWithSubRouteLetter:@"t"];
+    NSString *expectedText = sharerInstance.remoteConfiguration.twitterShare.text;
     OCMExpect([socialComposeVCMock setInitialText:expectedText]);
     OCMExpect([socialComposeVCMock setCompletionHandler:[OCMArg any]]);
 
@@ -497,7 +497,7 @@
     OCMExpect([sharerMock releaseSelf]);
 
     // expectations for content to pass to share view controller
-    NSString *expectedText = [MAVESharer shareCopyFromCopy:sharerInstance.remoteConfiguration.clipboardShare.text andLinkWithSubRouteLetter:@"c"];
+    NSString *expectedText = sharerInstance.remoteConfiguration.clipboardShare.text;
     OCMExpect([pasteboardMock setString:expectedText]);
 
     // run code under test

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationClientSMSTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationClientSMSTests.m
@@ -11,6 +11,7 @@
 #import <OCMock/OCMock.h>
 #import "MAVERemoteConfigurationClientSMS.h"
 #import "MAVETemplatingUtils.h"
+#import "MAVESharer.h"
 
 @interface MAVERemoteConfigurationClientSMSTests : XCTestCase
 
@@ -71,9 +72,13 @@
 }
 
 - (void)testTextFillsInTemplate {
+    id sharerMock = OCMClassMock([MAVESharer class]);
+    OCMExpect([sharerMock shareLinkWithSubRouteLetter:@"s"]).andReturn(@"fakeLink");
+
     id templatingUtilsMock = OCMClassMock([MAVETemplatingUtils class]);
-    NSString *templateString = @"{{ customData.foo }}";
-    OCMExpect([templatingUtilsMock interpolateWithSingletonDataTemplateString:templateString]).andReturn(@"bar1");
+    NSString *templateString = @"some template";
+    NSString *tmplWithLink = @"some template {{ link }}";
+    OCMExpect([templatingUtilsMock interpolateTemplateString:tmplWithLink withUser:[OCMArg any] link:@"fakeLink"]).andReturn(@"bar1");
 
     MAVERemoteConfigurationClientSMS *clientSMSConfig = [[MAVERemoteConfigurationClientSMS alloc] init];
     clientSMSConfig.textTemplate = templateString;
@@ -81,6 +86,7 @@
     NSString *output = [clientSMSConfig text];
 
     OCMVerifyAll(templatingUtilsMock);
+    OCMVerifyAll(sharerMock);
     XCTAssertEqualObjects(output, @"bar1");
 }
 

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationClipboardShareTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationClipboardShareTests.m
@@ -11,6 +11,7 @@
 #import <OCMock/OCMock.h>
 #import "MAVERemoteConfigurationClipboardShare.h"
 #import "MAVETemplatingUtils.h"
+#import "MAVESharer.h"
 
 @interface MAVERemoteConfigurationClipboardShareTests : XCTestCase
 
@@ -71,9 +72,13 @@
 }
 
 - (void)testTextFillsInTemplate {
+    id sharerMock = OCMClassMock([MAVESharer class]);
+    OCMExpect([sharerMock shareLinkWithSubRouteLetter:@"c"]).andReturn(@"fakeLink");
+
     id templatingUtilsMock = OCMClassMock([MAVETemplatingUtils class]);
-    NSString *templateString = @"{{ customData.foo }}";
-    OCMExpect([templatingUtilsMock interpolateWithSingletonDataTemplateString:templateString]).andReturn(@"bar1");
+    NSString *templateString = @"some text";
+    NSString *tmplWithLink = @"some text {{ link }}";
+    OCMExpect([templatingUtilsMock interpolateTemplateString:tmplWithLink withUser:[OCMArg any] link:@"fakeLink"]).andReturn(@"bar1");
 
     MAVERemoteConfigurationClipboardShare *twitterShareConfig = [[MAVERemoteConfigurationClipboardShare alloc] init];
     twitterShareConfig.textTemplate = templateString;

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationFacebookShareTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationFacebookShareTests.m
@@ -71,8 +71,8 @@
 
 - (void)testTextFillsInTemplate {
     id templatingUtilsMock = OCMClassMock([MAVETemplatingUtils class]);
-    NSString *templateString = @"{{ customData.foo }}";
-    OCMExpect([templatingUtilsMock interpolateWithSingletonDataTemplateString:templateString]).andReturn(@"bar1");
+    NSString *templateString = @"some string";
+    OCMExpect([templatingUtilsMock interpolateTemplateString:templateString withUser:[OCMArg any] link:nil]).andReturn(@"bar1");
 
     MAVERemoteConfigurationFacebookShare *facebookShareConfig = [[MAVERemoteConfigurationFacebookShare alloc] init];
     facebookShareConfig.textTemplate = templateString;

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMSTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationServerSMSTests.m
@@ -74,8 +74,8 @@
 
 - (void)testTextFillsInTemplate {
     id templatingUtilsMock = OCMClassMock([MAVETemplatingUtils class]);
-    NSString *templateString = @"{{ customData.foo }}";
-    OCMExpect([templatingUtilsMock interpolateWithSingletonDataTemplateString:templateString]).andReturn(@"bar1");
+    NSString *templateString = @"some text ";
+    OCMExpect([templatingUtilsMock interpolateTemplateString:templateString withUser:[OCMArg any] link:@"{{ link }}"]).andReturn(@"bar1");
 
     MAVERemoteConfigurationServerSMS *serverSMSConfig = [[MAVERemoteConfigurationServerSMS alloc] init];
     serverSMSConfig.textTemplate = templateString;

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationTwitterShareTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationTwitterShareTests.m
@@ -11,6 +11,7 @@
 #import <OCMock/OCMock.h>
 #import "MAVERemoteConfigurationTwitterShare.h"
 #import "MAVETemplatingUtils.h"
+#import "MAVESharer.h"
 
 @interface MAVERemoteConfigurationTwitterShareTests : XCTestCase
 
@@ -70,9 +71,13 @@
 }
 
 - (void)testTextFillsInTemplate {
+    id sharerMock = OCMClassMock([MAVESharer class]);
+    OCMExpect([sharerMock shareLinkWithSubRouteLetter:@"t"]).andReturn(@"fakeLink");
+
     id templatingUtilsMock = OCMClassMock([MAVETemplatingUtils class]);
-    NSString *templateString = @"{{ customData.foo }}";
-    OCMExpect([templatingUtilsMock interpolateWithSingletonDataTemplateString:templateString]).andReturn(@"bar1");
+    NSString *templateString = @"some text";
+    NSString *tmplWithLink = @"some text {{ link }}";
+    OCMExpect([templatingUtilsMock interpolateTemplateString:tmplWithLink withUser:[OCMArg any] link:@"fakeLink"]).andReturn(@"bar1");
 
     MAVERemoteConfigurationTwitterShare *twitterShareConfig = [[MAVERemoteConfigurationTwitterShare alloc] init];
     twitterShareConfig.textTemplate = templateString;
@@ -80,6 +85,7 @@
     NSString *output = [twitterShareConfig text];
 
     OCMVerifyAll(templatingUtilsMock);
+    OCMVerifyAll(sharerMock);
     XCTAssertEqualObjects(output, @"bar1");
 }
 

--- a/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
+++ b/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
@@ -30,30 +30,30 @@
 
 - (void)testInterpolateTemplateStringNoInterpolation {
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
-    NSDictionary *customData = @{@"foo_field": @"blah"};
+    user.customData = @{@"foo_field": @"blah"};
     NSString *template = @"Hello there";
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user customData:customData];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user];
 
     NSString *expected = template;
     XCTAssertEqualObjects(output, expected);
 }
 
 - (void)testInterpolateTemplateStringNoInterpolationNils {
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:@"Foo" withUser:nil customData:nil];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:@"Foo" withUser:nil];
 
     XCTAssertEqualObjects(output, @"Foo");
 }
 
 - (void)testInterpolateTemplateStringNil {
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:nil withUser:nil customData:nil];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:nil withUser:nil];
     XCTAssertNil(output);
 }
 
 - (void)testInterpolateTemplateStringSimpleWithUserAndCustomData {
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
-    NSDictionary *customData = @{@"foo_field": @"blah"};
+    user.customData = @{@"foo_field": @"blah"};
     NSString *template = @"{{ user.firstName }} is \"{{customData.foo_field}}\"";
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user customData:customData];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user];
 
     NSString *expected = @"Foo is \"blah\"";
     XCTAssertEqualObjects(output, expected);
@@ -61,9 +61,10 @@
 
 - (void)testInterpolateTemplateStringAllUserFields {
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
+    user.customData = @{};
     user.promoCode = @"123foo";
     NSString *template = @"{{ user.userID }} {{ user.firstName }} {{ user.lastName }} '{{ user.fullName }}' {{ user.promoCode }}";
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user customData:@{}];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user];
 
     NSString *expected = @"1 Foo Bar 'Foo Bar' 123foo";
     XCTAssertEqualObjects(output, expected);
@@ -71,8 +72,9 @@
 
 - (void)testInterpolateTemplateStringMissingStringLeavesEmpty {
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
+    user.customData = nil;
     NSString *template = @"{{ user.firstName }} is not \"{{ firstName }}\"";
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user customData:nil];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user];
 
     NSString *expected = @"Foo is not \"\"";
     XCTAssertEqualObjects(output, expected);
@@ -95,17 +97,19 @@
 }
 
 - (void)testInterpolateTemplateStringConvertsValuesToStrings {
-    NSDictionary *customData = @{@"a": @19, @"b": @(19.55), @"c": @(YES), @"d": [NSNull null], @"e": @"string", @"f": [[MAVEUserData alloc] init]};
+    MAVEUserData *user = [[MAVEUserData alloc] init];
+    user.customData = @{@"a": @19, @"b": @(19.55), @"c": @(YES), @"d": [NSNull null], @"e": @"string", @"f": [[MAVEUserData alloc] init]};
     NSString *templateString = @"a {{ customData.a }} b {{ customData.b }} c {{ customData.c }} d {{ customData.d }} e {{ customData.e }} f {{ customData.f }}";
 
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:templateString withUser:nil customData:customData];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:templateString withUser:user];
     NSString *expected = @"a 19 b 19.55 c 1 d <null> e string f ";
     XCTAssertEqualObjects(output, expected);
 }
 
 - (void)testInterpolateTemplateStringSkipsNonStringKeys {
-    NSDictionary *customData = @{@(19): @"foo"};
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:@"{{ customData.19 }}" withUser:nil customData:customData];
+    MAVEUserData *user = [[MAVEUserData alloc] init];
+    user.customData = @{@(19): @"foo"};
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:@"{{ customData.19 }}" withUser:user];
     XCTAssertEqualObjects(output, @"");
 }
 

--- a/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
+++ b/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
@@ -32,30 +32,30 @@
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
     user.customData = @{@"foo_field": @"blah"};
     NSString *template = @"Hello there";
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user link:nil];
 
     NSString *expected = template;
     XCTAssertEqualObjects(output, expected);
 }
 
 - (void)testInterpolateTemplateStringNoInterpolationNils {
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:@"Foo" withUser:nil];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:@"Foo" withUser:nil link:nil];
 
     XCTAssertEqualObjects(output, @"Foo");
 }
 
 - (void)testInterpolateTemplateStringNil {
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:nil withUser:nil];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:nil withUser:nil link:nil];
     XCTAssertNil(output);
 }
 
-- (void)testInterpolateTemplateStringSimpleWithUserAndCustomData {
+- (void)testInterpolateTemplateStringSimpleWithUserCustomDataAndLink {
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
     user.customData = @{@"foo_field": @"blah"};
-    NSString *template = @"{{ user.firstName }} is \"{{customData.foo_field}}\"";
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user];
+    NSString *template = @"{{ user.firstName }} at {{ link}} is \"{{customData.foo_field}}\"";
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user link:@"http://example.com"];
 
-    NSString *expected = @"Foo is \"blah\"";
+    NSString *expected = @"Foo at http://example.com is \"blah\"";
     XCTAssertEqualObjects(output, expected);
 }
 
@@ -64,7 +64,7 @@
     user.customData = @{};
     user.promoCode = @"123foo";
     NSString *template = @"{{ user.userID }} {{ user.firstName }} {{ user.lastName }} '{{ user.fullName }}' {{ user.promoCode }}";
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user link:nil];
 
     NSString *expected = @"1 Foo Bar 'Foo Bar' 123foo";
     XCTAssertEqualObjects(output, expected);
@@ -74,7 +74,7 @@
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
     user.customData = nil;
     NSString *template = @"{{ user.firstName }} is not \"{{ firstName }}\"";
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:template withUser:user link:nil];
 
     NSString *expected = @"Foo is not \"\"";
     XCTAssertEqualObjects(output, expected);
@@ -101,7 +101,7 @@
     user.customData = @{@"a": @19, @"b": @(19.55), @"c": @(YES), @"d": [NSNull null], @"e": @"string", @"f": [[MAVEUserData alloc] init]};
     NSString *templateString = @"a {{ customData.a }} b {{ customData.b }} c {{ customData.c }} d {{ customData.d }} e {{ customData.e }} f {{ customData.f }}";
 
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:templateString withUser:user];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:templateString withUser:user link:nil];
     NSString *expected = @"a 19 b 19.55 c 1 d <null> e string f ";
     XCTAssertEqualObjects(output, expected);
 }
@@ -109,7 +109,7 @@
 - (void)testInterpolateTemplateStringSkipsNonStringKeys {
     MAVEUserData *user = [[MAVEUserData alloc] init];
     user.customData = @{@(19): @"foo"};
-    NSString *output = [MAVETemplatingUtils interpolateTemplateString:@"{{ customData.19 }}" withUser:user];
+    NSString *output = [MAVETemplatingUtils interpolateTemplateString:@"{{ customData.19 }}" withUser:user link:nil];
     XCTAssertEqualObjects(output, @"");
 }
 

--- a/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
+++ b/MaveSDKTests/Utils/MAVETemplatingUtilsTests.m
@@ -109,6 +109,35 @@
     XCTAssertEqualObjects(output, @"");
 }
 
+- (void)testAppendLinkVariableToTemplateStringIfNeededWhenNeeded {
+    NSString *tmpl0 = @"Simple string";
+    NSString *exp0 = @"Simple string {{ link }}";
+    NSString *output0 = [MAVETemplatingUtils appendLinkVariableToTemplateStringIfNeeded:tmpl0];
+    XCTAssertEqualObjects(output0, exp0);
+
+    NSString *tmpl1 = @"String without {{ link variable";
+    NSString *exp1 = @"String without {{ link variable {{ link }}";
+    NSString *output1 = [MAVETemplatingUtils appendLinkVariableToTemplateStringIfNeeded:tmpl1];
+    XCTAssertEqualObjects(output1, exp1);
+
+    // don't add an extra string if it ends in whitespace
+    NSString *tmpl2 = @"String ending in whitespace ";
+    NSString *exp2 = @"String ending in whitespace {{ link }}";
+    NSString *output2 = [MAVETemplatingUtils appendLinkVariableToTemplateStringIfNeeded:tmpl2];
+    XCTAssertEqualObjects(output2, exp2);
+
+    // doesn't break for empty string or nil
+    XCTAssertEqualObjects([MAVETemplatingUtils appendLinkVariableToTemplateStringIfNeeded:@""], @"{{ link }}");
+    XCTAssertEqualObjects([MAVETemplatingUtils appendLinkVariableToTemplateStringIfNeeded:nil], @"{{ link }}");
+
+}
+
+- (void)testAppendLinkVariableToTemplateStringIfNeededWhenNotNeeded {
+    NSString *tmpl0 = @"Some string with {{  link}} variable";
+    NSString *output = [MAVETemplatingUtils appendLinkVariableToTemplateStringIfNeeded:tmpl0];
+    XCTAssertEqualObjects(tmpl0, output);
+}
+
 - (void)testInterpolateWithSingletonData {
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Foo" lastName:@"Bar"];
     user.customData = @{@"other_field": @"blahz"};


### PR DESCRIPTION
Change how we render messages, regarding links. We were always appending the link to the end of the message copy (from before we had any templating). Now that we use templating for other variables, we can do the same for the link and let developers put the link in the middle of the message copy if they wish.

This works for client shares (except facebook, where the url is a separate metadata value on the post and shouldn't be in the text) as well as server-side sms and email.

And this change is backwards compatible with old versions of the SDK, if the {{ link }} variable is not found anywhere in the template body it still gets appended to the end of the message as before.