### PR TITLE
Make client-side only

### DIFF
--- a/DemoApp/AppDelegate.m
+++ b/DemoApp/AppDelegate.m
@@ -26,7 +26,7 @@
 }
 
 - (void)setupMaveSDK {
-    [MaveSDK setupSharedInstanceWithApplicationID:MAVEDemoApplicationID];
+    [MaveSDK setupSharedInstance];
 
     MAVEUserData *userData = [[MAVEUserData alloc] initWithUserID:@"1"
                                                         firstName:@"Example"

--- a/LICENSE
+++ b/LICENSE
@@ -1,34 +1,23 @@
-Copyright (c) 2014-2015 Mave Technologies, Inc.  All rights reserved.
+Copyright (c) 2015 Mave Technologies, Inc.  All rights reserved.
 
-Subject to the terms of this notice, Mave Technologies grants you a
-nonexclusive, nontransferable license, without the right to sublicense, to
-(a) install and execute one copy of these files for testing purposes on any
-number of workstations or mobile devices owned or controlled by you and (b)
-distribute verbatim copies of these files to third parties. As a condition
-to the foregoing grant, you must provide this notice along with each copy
-you distribute and you must not remove, alter, or obscure this notice. All
-other use, reproduction, modification, distribution, or other exploitation
-of these files is strictly prohibited, except as may be set forth in a
-separate written license agreement between you and Mave Technologies. The
-terms of any such license agreement will control over this notice. The
-license stated above will be automatically terminated and revoked if you
-exceed its scope or violate any of the terms of this notice.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-This License does not grant permission to use the trade names, trademarks,
-service marks, or product names of Mave Technologies, except as required
-for reasonable and customary use of these files and reproducing the content
-of this notice. You may not mark or brand this file with any trade name,
-trademarks, service marks, or product names other than the original brand
-(if any) provided by Mave Technologies, and you may not remove or hide any
-existing mark or brand provided by Mave Technologies, except as may be set
-forth in a separate written license agreement between you and Mave
-Technologies.
 
-Unless otherwise expressly agreed by Mave Technologies in a separate
-written license agreement, these files are provided AS IS, WITHOUT WARRANTY
-OF ANY KIND, including without any implied warranties of MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT. As a
-condition to your use of these files, you are solely responsible for such
-use. Mave Technologies will have no liability to you for direct, indirect,
-consequential, incidental, special, or punitive damages or for lost profits
-or data.
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/MaveSDK.podspec
+++ b/MaveSDK.podspec
@@ -10,16 +10,15 @@
 
 Pod::Spec.new do |s|
   s.name             = "MaveSDK"
-  s.version          = "0.7.11"
-  s.summary          = "A drop-in SMS invite and share platform to accelerate your user growth"
+  s.version          = "0.8.0"
+  s.summary          = "A drop-in SMS invite and share page to accelerate your user growth"
   s.description      = <<-DESC
-                       Make it simple for your users to send more, higher quality invites and shares.
+                       Mave the service has shut down as of Dec 2015.
 
-                       Sign up on our website to get started, and be up and running in 20 minutes
-                       with an invite page that's as good or better as what the top apps are using.
+                       This library is still functional as a stand-alone invite or share page, but the Mave-provided services such as SMS invite delivery, the stats dashboard, and suggested invites are no longer available. The library is now released under the MIT license.
                        DESC
-  s.homepage         = "http://mave.io"
-  s.license          = 'Proprietary'
+  s.homepage         = "https://github.com/mave/mave-ios-sdk"
+  s.license          = 'MIT'
   s.author           = 'Mave'
   s.source           = { :git => "https://github.com/mave/mave-ios-sdk.git", :tag => "v#{s.version.to_s}" }
   s.social_media_url = 'https://twitter.com/mavegrowth'

--- a/MaveSDK/Controllers/MAVEABPermissionPromptHandler.m
+++ b/MaveSDK/Controllers/MAVEABPermissionPromptHandler.m
@@ -50,27 +50,24 @@
 
 
     // Otherwise, decide how to prompt and prompt
-    [[MaveSDK sharedInstance].remoteConfigurationBuilder
-     createObjectWithTimeout:1.0 completionBlock:^(id object) {
-        MAVERemoteConfiguration *remoteConfig = object;
-        this.prePromptTemplate = remoteConfig.contactsPrePrompt;
+    MAVERemoteConfiguration *remoteConfig = [[MaveSDK sharedInstance] remoteConfiguration];
+    this.prePromptTemplate = remoteConfig.contactsPrePrompt;
 
-        if (remoteConfig.contactsPrePrompt.enabled) {
-            // purposely create retain cycle so it won't get dealloc'ed until alert view
-            // is displayed then dismissed
-            this.retainSelf = this;
+    if (remoteConfig.contactsPrePrompt.enabled) {
+        // purposely create retain cycle so it won't get dealloc'ed until alert view
+        // is displayed then dismissed
+        this.retainSelf = this;
 
-            [this logContactsPromptRelatedEventWithRoute:MAVERouteTrackContactsPrePermissionPromptView];
-            [this showPrePromptAlertWithTitle:this.prePromptTemplate.title
-                                      message:this.prePromptTemplate.message
-                             cancelButtonCopy:this.prePromptTemplate.cancelButtonCopy
-                             acceptbuttonCopy:this.prePromptTemplate.acceptButtonCopy];
+        [this logContactsPromptRelatedEventWithRoute:MAVERouteTrackContactsPrePermissionPromptView];
+        [this showPrePromptAlertWithTitle:this.prePromptTemplate.title
+                                  message:this.prePromptTemplate.message
+                         cancelButtonCopy:this.prePromptTemplate.cancelButtonCopy
+                         acceptbuttonCopy:this.prePromptTemplate.acceptButtonCopy];
 
-        } else {
-            [this logContactsPromptRelatedEventWithRoute:MAVERouteTrackContactsPermissionPromptView];
-            [this loadAddressBookAndComplete];
-        }
-    }];
+    } else {
+        [this logContactsPromptRelatedEventWithRoute:MAVERouteTrackContactsPermissionPromptView];
+        [this loadAddressBookAndComplete];
+    }
     return this;
 }
 

--- a/MaveSDK/Controllers/MAVEInvitePageViewController.m
+++ b/MaveSDK/Controllers/MAVEInvitePageViewController.m
@@ -436,10 +436,6 @@
     MaveSDK *mave = [MaveSDK sharedInstance];
     NSMutableArray *activityItems = [[NSMutableArray alloc] init];
     [activityItems addObject:mave.defaultSMSMessageText];
-    if ([mave.appId isEqualToString:MAVEPartnerApplicationIDSwig] ||
-        [mave.appId isEqualToString:MAVEPartnerApplicationIDSwigEleviter]) {
-        [activityItems addObject:[NSURL URLWithString:MAVEInviteURLSwig]];
-    }
     
     UIActivityViewController *activityVC = [[UIActivityViewController alloc]
                                             initWithActivityItems:activityItems

--- a/MaveSDK/MAVEConstants.m
+++ b/MaveSDK/MAVEConstants.m
@@ -8,7 +8,7 @@
 
 #import "MAVEConstants.h"
 
-NSString * const MAVESDKVersion = @"0.7.11";
+NSString * const MAVESDKVersion = @"0.8.0";
 
 #ifdef MAVE_USE_DEV_API
 

--- a/MaveSDK/MaveSDK.h
+++ b/MaveSDK/MaveSDK.h
@@ -12,9 +12,9 @@
 #import "MAVEUserData.h"
 #import "MAVEReferringData.h"
 #import "MAVEInvitePageChooser.h"
+#import "MAVERemoteConfiguration.h"
 #import "MAVERemoteConfigurationInvitePageChoice.h"
 #import "MAVEAPIInterface.h"
-#import "MAVERemoteObjectBuilder.h"
 #import "MAVECustomSharePageViewController.h"
 #import "MAVEABSyncManager.h"
 #import "MAVEInviteSender.h"
@@ -27,7 +27,7 @@
 @property (nonatomic, strong) MAVEABSyncManager *addressBookSyncManager;
 @property (nonatomic, strong) MAVEInvitePageChooser *invitePageChooser;
 @property (nonatomic, strong) MAVEInviteSender *inviteSender;
-@property (nonatomic, strong) MAVERemoteObjectBuilder *remoteConfigurationBuilder;
+@property (nonatomic, strong) MAVERemoteConfiguration *remoteConfiguration;
 @property (nonatomic, strong) MAVERemoteObjectBuilder *shareTokenBuilder;
 @property (nonatomic, strong) MAVERemoteObjectBuilder *suggestedInvitesBuilder;
 @property (nonatomic, strong) MAVERemoteObjectBuilder *referringDataBuilder;

--- a/MaveSDK/MaveSDK.h
+++ b/MaveSDK/MaveSDK.h
@@ -32,7 +32,6 @@
 @property (nonatomic, strong) MAVERemoteObjectBuilder *suggestedInvitesBuilder;
 @property (nonatomic, strong) MAVERemoteObjectBuilder *referringDataBuilder;
 
-@property (nonatomic, copy) NSString *appId;
 @property (nonatomic, copy) NSString *appDeviceID;
 @property (nonatomic, assign) BOOL isInitialAppLaunch;
 @property (nonatomic, copy) NSString *inviteContext;
@@ -47,7 +46,7 @@
 @property (nonatomic, assign) CGFloat debugSuggestedInvitesDelaySeconds;
 
 
-+ (void)setupSharedInstanceWithApplicationID:(NSString *)applicationID;
++ (void)setupSharedInstance;
 + (instancetype)sharedInstance;
 
 // Methods intended for external use, to access referring data & suggested invites

--- a/MaveSDK/MaveSDK.m
+++ b/MaveSDK/MaveSDK.m
@@ -42,6 +42,7 @@
         _APIInterface = [[MAVEAPIInterface alloc] initWithBaseURL:apiBaseURL];
         _addressBookSyncManager = [[MAVEABSyncManager alloc] init];
         _inviteSender = [[MAVEInviteSender alloc] init];
+        _remoteConfiguration = [[MAVERemoteConfiguration alloc] initWithDictionary:[MAVERemoteConfiguration defaultJSONData]];
     }
     return self;
 }
@@ -56,7 +57,6 @@ static dispatch_once_t sharedInstanceonceToken;
         sharedInstance.referringDataBuilder = [MAVEReferringData remoteBuilderNoPreFetch];
         [sharedInstance.APIInterface trackAppOpenFetchingReferringDataWithPromise:sharedInstance.referringDataBuilder.promise];
 
-        sharedInstance.remoteConfigurationBuilder = [MAVERemoteConfiguration remoteBuilder];
         sharedInstance.suggestedInvitesBuilder = [MAVESuggestedInvites remoteBuilder];
 
 
@@ -117,11 +117,6 @@ static dispatch_once_t sharedInstanceonceToken;
         ok = NO;
     }
     return ok;
-}
-
-- (MAVERemoteConfiguration *)remoteConfiguration {
-    id obj = [self.remoteConfigurationBuilder createObjectSynchronousWithTimeout:0];
-    return (MAVERemoteConfiguration *)obj;
 }
 
 

--- a/MaveSDK/MaveSDK.m
+++ b/MaveSDK/MaveSDK.m
@@ -30,10 +30,8 @@
 //
 // Init and handling shared instance & needed data
 //
-- (instancetype)initWithAppId:(NSString *)appId {
+- (instancetype)initCustom {
     if (self = [self init]) {
-        _appId = appId;
-
         _isInitialAppLaunch = ![MAVEIDUtils isAppDeviceIDStoredToDefaults];
         _appDeviceID = [MAVEIDUtils loadOrCreateNewAppDeviceID];
 
@@ -50,9 +48,9 @@
 static MaveSDK *sharedInstance = nil;
 static dispatch_once_t sharedInstanceonceToken;
 
-+ (void)setupSharedInstanceWithApplicationID:(NSString *)applicationID {
++ (void)setupSharedInstance {
     dispatch_once(&sharedInstanceonceToken, ^{
-        sharedInstance = [[self alloc] initWithAppId:applicationID];
+        sharedInstance = [[self alloc] initCustom];
 
         sharedInstance.referringDataBuilder = [MAVEReferringData remoteBuilderNoPreFetch];
         [sharedInstance.APIInterface trackAppOpenFetchingReferringDataWithPromise:sharedInstance.referringDataBuilder.promise];
@@ -88,10 +86,7 @@ static dispatch_once_t sharedInstanceonceToken;
 - (NSError *)validateUserSetup {
     NSInteger errCode = 0;
     NSString *humanError = @"";
-    if (self.appId == nil) {
-        humanError = @"applicationID is nil";
-        errCode = MAVEValidationErrorApplicationIDNotSetCode;
-    } else if (self.userData == nil) {
+    if (self.userData == nil) {
         humanError = @"identifyUser not called";
         errCode = MAVEValidationErrorUserIdentifyNeverCalledCode;
     } else if (self.userData.userID == nil) {
@@ -110,13 +105,7 @@ static dispatch_once_t sharedInstanceonceToken;
 }
 
 - (BOOL)isSetupOK {
-    NSString *errorFormat = @"Issue with MaveSDK setup - %@.";
-    BOOL ok = YES;
-    if (!self.appId) {
-        MAVEErrorLog(errorFormat, @"applicationID is nil");
-        ok = NO;
-    }
-    return ok;
+    return YES;
 }
 
 

--- a/MaveSDK/MaveSDK_Internal.h
+++ b/MaveSDK/MaveSDK_Internal.h
@@ -15,7 +15,7 @@
 
 @interface MaveSDK (Internal)
 
-- (instancetype)initWithAppId:(NSString *)appId;
+- (instancetype)initCustom;
 
 // This function checks that required fields for the MaveSDK invite page to work
 // correctly have been initialized. It logs any errors with a big "ERROR"

--- a/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePage.m
+++ b/MaveSDK/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePage.m
@@ -100,7 +100,7 @@ NSString * const MAVERemoteConfigKeyContactsInvitePageSMSSendMethodClientSideGro
             MAVERemoteConfigKeyContactsInvitePageIncludeShareButtons: @NO,
             MAVERemoteConfigKeyContactsInvitePageSuggestedInvitesEnabled: @NO,
             MAVERemoteConfigKeyContactsInvitePageSelectAllEnabled: @NO,
-            MAVERemoteConfigKeyContactsInvitePageSMSSendMethod: MAVERemoteConfigKeyContactsInvitePageSMSSendMethodServerSide,
+            MAVERemoteConfigKeyContactsInvitePageSMSSendMethod: MAVERemoteConfigKeyContactsInvitePageSMSSendMethodClientSideGroup,
             MAVERemoteConfigKeyContactsInvitePageReusableSuggestedInviteCellSendIcon: MAVERemoteConfigKeyContactsInvitePageReusableSuggestedInviteCellSendIconAirplane,
         }
     };

--- a/MaveSDK/Networking/MAVEAPIInterface.m
+++ b/MaveSDK/Networking/MAVEAPIInterface.m
@@ -57,7 +57,7 @@ NSString * const MAVEAPIHeaderContextPropertiesInviteContext = @"invite_context"
 }
 
 - (NSString *)applicationID {
-    return [MaveSDK sharedInstance].appId;
+    return @"<NO APP ID>";
 }
 
 - (NSString *)applicationDeviceID {

--- a/MaveSDK/Networking/MAVEHTTPStack.m
+++ b/MaveSDK/Networking/MAVEHTTPStack.m
@@ -156,7 +156,7 @@
             completionBlock:(MAVEHTTPCompletionBlock)completionBlock {
     // No-op sending actual requests so the client doesn't rely on the API
     // Still call the completion block with a hard-coded error in case there's code that needs to run
-    [self handleJSONResponseWithData:nil response:nil error:nil completionBlock:completionBlock];
+    [self handleJSONResponseWithData:nil response:nil error:[NSError errorWithDomain:@"" code:0 userInfo:nil] completionBlock:completionBlock];
 }
 
 ///

--- a/MaveSDK/Networking/MAVEHTTPStack.m
+++ b/MaveSDK/Networking/MAVEHTTPStack.m
@@ -154,17 +154,9 @@
 
 - (void)sendPreparedRequest:(NSURLRequest *)request
             completionBlock:(MAVEHTTPCompletionBlock)completionBlock {
-    // Send request
-    NSURLSessionTask *task = [self.session dataTaskWithRequest:request
-                    completionHandler: ^(NSData *data, NSURLResponse *response, NSError *error) {
-        NSString *logMessage = [NSString stringWithFormat:@"\"%lu\" %@ %@", (long)((NSHTTPURLResponse *)response).statusCode, request.HTTPMethod, request.URL];
-        self.requestLoggingBlock(logMessage);
-        [self handleJSONResponseWithData:data
-                                response:response
-                                   error:error
-                         completionBlock:completionBlock];
-    }];
-    [task resume];
+    // No-op sending actual requests so the client doesn't rely on the API
+    // Still call the completion block with a hard-coded error in case there's code that needs to run
+    [self handleJSONResponseWithData:nil response:nil error:nil completionBlock:completionBlock];
 }
 
 ///

--- a/MaveSDK/Utils/MAVEClientPropertyUtils.m
+++ b/MaveSDK/Utils/MAVEClientPropertyUtils.m
@@ -269,7 +269,7 @@
 // Try to use the integer encoding so it'll be as short as possible, but if
 // app ID is not a valid 8 byte integer just encode as utf8 string
 + (NSString *)urlSafeBase64ApplicationID {
-    NSString *appID = [MaveSDK sharedInstance].appId;
+    NSString *appID = @"<NO App ID>";
 
     // check if it's an 8 byte integer by converting to a number then back
     // to string and making sure it's the same number

--- a/MaveSDK/Utils/MAVEClientPropertyUtils.m
+++ b/MaveSDK/Utils/MAVEClientPropertyUtils.m
@@ -176,7 +176,7 @@
     // If any are nil, set to NSNull so the json key will still be created with "null"
     // Note that these could all be the default value of "0" or the previously-saved value
     // if the remote configuration hasn't returned yet (e.g. the track app open request).
-    MAVERemoteConfiguration *remoteConfig = [MaveSDK sharedInstance].remoteConfigurationBuilder.object;
+    MAVERemoteConfiguration *remoteConfig = [MaveSDK sharedInstance].remoteConfiguration;
     propertyVal = remoteConfig.contactsPrePrompt.templateID;
     if (!propertyVal) {propertyVal = (NSString *)[NSNull null];}
     [properties setValue:propertyVal forKey:@"contacts_pre_permission_prompt_template_id"];

--- a/MaveSDKTests/Controllers/MAVEABPermissionPromptHandlerTest.m
+++ b/MaveSDKTests/Controllers/MAVEABPermissionPromptHandlerTest.m
@@ -98,16 +98,7 @@
         initWithDictionary:[MAVERemoteConfiguration defaultJSONData]];
     XCTAssertTrue(remoteConfig.contactsPrePrompt.enabled);
 
-    // whole prompt method is wrapped in a block waiting on remote configuration
-    // so we have to use mock check block to actually call the code we'll test
-    id buildConfigMock = OCMClassMock([MAVERemoteObjectBuilder class]);
-    [MaveSDK sharedInstance].remoteConfigurationBuilder = buildConfigMock;
-    OCMStub([buildConfigMock createObjectWithTimeout:1.0 completionBlock:
-             [OCMArg checkWithBlock:^BOOL(id obj) {
-        void(^completionBlock)(id) = obj;
-        completionBlock(remoteConfig);
-        return YES;
-    }]]);
+    [MaveSDK sharedInstance].remoteConfiguration = remoteConfig;
 
     OCMExpect([permissionPrompterMock setBeganFlowAsStatusUnprompted:YES]);
 
@@ -140,16 +131,7 @@
     MAVERemoteConfiguration *remoteConfig = [[MAVERemoteConfiguration alloc] init];
     remoteConfig.contactsPrePrompt.enabled = 0;
 
-    // Since method under test is in a block, this wrapper calls the block to test the code
-    id buildConfigMock = OCMClassMock([MAVERemoteObjectBuilder class]);
-    [MaveSDK sharedInstance].remoteConfigurationBuilder = buildConfigMock;
-    OCMStub([buildConfigMock createObjectWithTimeout:2.0 completionBlock:
-             [OCMArg checkWithBlock:^BOOL(id obj) {
-        void(^completionBlock)(id) = obj;
-        completionBlock(remoteConfig);
-        return YES;
-    }]]);
-
+    [MaveSDK sharedInstance].remoteConfiguration = remoteConfig;
     MAVEABDataBlock completionBlock = ^void(NSArray *data){};
 
     // set up expectaions

--- a/MaveSDKTests/Controllers/MAVEABPermissionPromptHandlerTest.m
+++ b/MaveSDKTests/Controllers/MAVEABPermissionPromptHandlerTest.m
@@ -186,7 +186,7 @@
 }
 
 - (void)testCompleteAfterPermissionUnfulfilledToGranted {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     NSArray *fakeContacts = @[[MAVEABTestDataFactory personWithFirstName:@"Foo" lastName:@"Cosson"]];
 
     // generate object under test and its block

--- a/MaveSDKTests/Controllers/MAVEABTableViewControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVEABTableViewControllerTests.m
@@ -29,7 +29,7 @@
 - (void)setUp {
     [super setUp];
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"1231234"];
+    [MaveSDK setupSharedInstance];
     [MaveSDK sharedInstance].userData = [[MAVEUserData alloc] init];
     [MaveSDK sharedInstance].userData.userID = @"foo";
     [MaveSDK sharedInstance].displayOptions =

--- a/MaveSDKTests/Controllers/MAVEContactsInvitePageV2ViewControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVEContactsInvitePageV2ViewControllerTests.m
@@ -27,7 +27,7 @@
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
 }
 
 - (void)tearDown {

--- a/MaveSDKTests/Controllers/MAVEContactsInvitePageV3ViewControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVEContactsInvitePageV3ViewControllerTests.m
@@ -257,7 +257,7 @@
 
 - (void)testSendRemoteInvites {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MaveSDK *mave = [MaveSDK sharedInstance];
     MAVEUserData *userData = [[MAVEUserData alloc] initWithUserID:@"456" firstName:@"Blah" lastName:@"Name"];
     mave.userData = userData;

--- a/MaveSDKTests/Controllers/MAVECustomSharePageViewControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVECustomSharePageViewControllerTests.m
@@ -38,7 +38,7 @@
     [super setUp];
     [MaveSDK resetSharedInstanceForTesting];
     self.applicationID = @"foo123";
-    [MaveSDK setupSharedInstanceWithApplicationID:self.applicationID];
+    [MaveSDK setupSharedInstance];
     self.viewController = nil;
     self.viewControllerMock = nil;
     self.sharerMock = nil;

--- a/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
+++ b/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
@@ -570,22 +570,13 @@
     MAVERemoteConfiguration *remoteConfig = [[MAVERemoteConfiguration alloc] init];
     remoteConfig.contactsInvitePage = [[MAVERemoteConfigurationContactsInvitePage alloc] init];
 
-    // Setup mock, test when enabled NO
-    id configBuilderMock = OCMPartialMock([MaveSDK sharedInstance].remoteConfigurationBuilder);
-    OCMExpect([configBuilderMock createObjectSynchronousWithTimeout:0]).andReturn(remoteConfig);
-    remoteConfig.contactsInvitePage.enabled = NO;
+    // Test when enabled NO
+    [MaveSDK sharedInstance].remoteConfiguration.contactsInvitePage.enabled = NO;
     XCTAssertFalse([chooser isContactsInvitePageEnabledServerSide]);
 
-    OCMVerifyAll(configBuilderMock);
-    [configBuilderMock stopMocking];
-
-    // Reset mock, test when enabled YES
-    configBuilderMock = OCMPartialMock([MaveSDK sharedInstance].remoteConfigurationBuilder);
-    remoteConfig.contactsInvitePage.enabled = YES;
-    OCMExpect([configBuilderMock createObjectSynchronousWithTimeout:0]).andReturn(remoteConfig);
+    // Test when enabled YES
+    [MaveSDK sharedInstance].remoteConfiguration.contactsInvitePage.enabled = YES;
     XCTAssertTrue([chooser isContactsInvitePageEnabledServerSide]);
-
-    OCMVerifyAll(configBuilderMock);
 }
 
 #pragma mark - Navigation controller setup logic

--- a/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
+++ b/MaveSDKTests/Controllers/MAVEInvitePageChooserTests.m
@@ -31,7 +31,7 @@
 - (void)setUp {
     [super setUp];
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
 }
 
 - (void)tearDown {
@@ -644,7 +644,7 @@
 
 - (void)testStyleNavigationController {
     // Uses display options from the singleton
-    [MaveSDK setupSharedInstanceWithApplicationID:@"appid1"];
+    [MaveSDK setupSharedInstance];
     MAVEDisplayOptions *displayOpts = [MAVEDisplayOptionsFactory generateDisplayOptions];
     [MaveSDK sharedInstance].displayOptions = displayOpts;
 

--- a/MaveSDKTests/Controllers/MAVEInvitePageViewControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVEInvitePageViewControllerTests.m
@@ -31,7 +31,7 @@
 - (void)setUp {
     [super setUp];
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"1231234"];
+    [MaveSDK setupSharedInstance];
     [MaveSDK sharedInstance].userData = [[MAVEUserData alloc] init];
     [MaveSDK sharedInstance].userData.userID = @"foo";
     [MaveSDK sharedInstance].displayOptions =
@@ -257,7 +257,7 @@
     }]]);
 
     // setup code and add test expectations
-    [MaveSDK setupSharedInstanceWithApplicationID:@"appid1"];
+    [MaveSDK setupSharedInstance];
 
     MAVEInvitePageViewController *vc = [[MAVEInvitePageViewController alloc] init];
     id mockVC = OCMPartialMock(vc);
@@ -282,7 +282,7 @@
     OCMExpect([mockPrompter promptForContactsWithCompletionBlock:[OCMArg any]]);
 
     // setup code and add test expectations
-    [MaveSDK setupSharedInstanceWithApplicationID:@"appid1"];
+    [MaveSDK setupSharedInstance];
 
     MAVEInvitePageViewController *vc = [[MAVEInvitePageViewController alloc] init];
     id mockVC = OCMPartialMock(vc);
@@ -353,7 +353,7 @@
 // Tests for the helper for displaying suggested invites
 - (void)testBuildContactsToUseAtPageRenderWhenShowSuggestedFlaggedOff {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"appid1"];
+    [MaveSDK setupSharedInstance];
 
     // flag off the show suggested flag
     MAVERemoteConfiguration *config = [[MAVERemoteConfiguration alloc] init];
@@ -381,7 +381,7 @@
 
 - (void)testBuildContactsToUseAtPageRenderWhenFlaggedOnAndContactsAlreadyReturned {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"appid1"];
+    [MaveSDK setupSharedInstance];
 
     // flag on the show suggested flag
     MAVERemoteConfiguration *config = [[MAVERemoteConfiguration alloc] init];
@@ -415,7 +415,7 @@
 
 - (void)testBuildContactsToUseAtPageRenderWhenFlaggedOnAndContactsAlreadyReturnedEmpty {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"appid1"];
+    [MaveSDK setupSharedInstance];
 
     // flag on the show suggested flag
     MAVERemoteConfiguration *config = [[MAVERemoteConfiguration alloc] init];
@@ -446,7 +446,7 @@
 
 - (void)testBuildContactsToUseAtPageRenderWhenFlaggedOnAndWaitingOnContactsToBeReturned {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"appid1"];
+    [MaveSDK setupSharedInstance];
 
     // flag on the show suggested flag
     MAVERemoteConfiguration *config = [[MAVERemoteConfiguration alloc] init];

--- a/MaveSDKTests/Controllers/MAVEInviteSenderTests.m
+++ b/MaveSDKTests/Controllers/MAVEInviteSenderTests.m
@@ -35,7 +35,7 @@
 
 - (void)testSendInviteToPerson {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo234"];
+    [MaveSDK setupSharedInstance];
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"123" firstName:@"Foo" lastName:@"Example"];
     user.inviteLinkDestinationURL = @"http://example.com/invite";
     user.wrapInviteLink = NO;

--- a/MaveSDKTests/Controllers/MAVESharerTests.m
+++ b/MaveSDKTests/Controllers/MAVESharerTests.m
@@ -28,7 +28,7 @@
 - (void)setUp {
     [super setUp];
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
 }
 
 - (void)tearDown {
@@ -512,7 +512,7 @@
 #pragma mark - Helpers for building share content
 - (void)testShareToken {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MAVEShareToken *tokenObj = [[MAVEShareToken alloc] init];
     tokenObj.shareToken = @"blahasdf";
     id mock = OCMClassMock([MAVERemoteObjectBuilder class]);
@@ -526,7 +526,7 @@
 
 - (void)testShareTokenNilWhenBuilderIsNil {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     [MaveSDK sharedInstance].shareTokenBuilder = nil;
 
     NSString *shareToken = [MAVESharer shareToken];
@@ -535,7 +535,7 @@
 
 - (void)testShareLinkBaseURLWhenCustom {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo124"];
+    [MaveSDK setupSharedInstance];
     MAVERemoteConfiguration *config = [[MAVERemoteConfiguration alloc] init];
     config.customSharePage = [[MAVERemoteConfigurationCustomSharePage alloc] init];
     config.customSharePage.inviteLinkBaseURL = @"http://foo.example.com";
@@ -550,7 +550,7 @@
 
 - (void)testShareLinkBaseURLWhenUsingDefault {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo124"];
+    [MaveSDK setupSharedInstance];
     MAVERemoteConfiguration *config = [[MAVERemoteConfiguration alloc] init];
     config.customSharePage = [[MAVERemoteConfigurationCustomSharePage alloc] init];
     config.customSharePage.inviteLinkBaseURL = nil;
@@ -585,7 +585,7 @@
 
 - (void)testBuildLinkWhenNotUsingMaveLinks {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Dan" lastName:@"Foo"];
     user.inviteLinkDestinationURL = @"http://example.com/abcd";
     user.wrapInviteLink = NO;
@@ -666,7 +666,7 @@
 #pragma mark - Tests for setup share token
 - (void)testSetupShareTokenStoresLinkDetailsAndSetsUpShareTokenBuilder {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     XCTAssertNil([MaveSDK sharedInstance].shareTokenBuilder);
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Dan" lastName:@"Foo"];
     user.inviteLinkDestinationURL = @"https://example.com/1";
@@ -707,7 +707,7 @@
 
 - (void)testSetupShareTokenDoesntClearExistingShareTokenIfDetailsSame {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
 
     // Manually store the link details for the current user object,
     // then when the setup share token method looks up the stored linke
@@ -734,7 +734,7 @@
 
 - (void)testSetupShareTokenDoesNothingIfNotUsingMaveLinks {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     XCTAssertNil([MaveSDK sharedInstance].shareTokenBuilder);
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1" firstName:@"Dan" lastName:@"Foo"];
     user.inviteLinkDestinationURL = @"https://example.com/1";
@@ -748,7 +748,7 @@
 
 - (void)testSetupShareTokenDoesNothingIfShareTokenBuilderAlreadyExists {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MAVERemoteObjectBuilder *emptyBuilder = [[MAVERemoteObjectBuilder alloc] init];
     [MaveSDK sharedInstance].shareTokenBuilder = emptyBuilder;
 

--- a/MaveSDKTests/Controllers/MAVEWrapperNavigationControllerTests.m
+++ b/MaveSDKTests/Controllers/MAVEWrapperNavigationControllerTests.m
@@ -28,7 +28,7 @@
 }
 
 - (void)testStatusBarStyle {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MaveSDK *mave = [MaveSDK sharedInstance];
     mave.displayOptions.statusBarStyle = UIStatusBarStyleLightContent;
     MAVEWrapperNavigationController *vc = [[MAVEWrapperNavigationController alloc] init];

--- a/MaveSDKTests/MaveSDKTests.m
+++ b/MaveSDKTests/MaveSDKTests.m
@@ -56,7 +56,7 @@
     XCTAssertNotNil(mave.displayOptions);
     XCTAssertEqualObjects(mave.defaultSMSMessageText, mave.remoteConfiguration.serverSMS.text);
     XCTAssertNotNil(mave.appDeviceID);
-    XCTAssertNotNil(mave.remoteConfigurationBuilder);
+    XCTAssertNotNil(mave.remoteConfiguration);
     XCTAssertNil(mave.shareTokenBuilder);
     XCTAssertNotNil(mave.addressBookSyncManager);
     XCTAssertNotNil(mave.inviteSender);
@@ -92,18 +92,6 @@
 }
 
 // Test getting properties on the mave object
-- (void) testRemoteConfiguration {
-    MAVERemoteObjectBuilder *builder = [[MAVERemoteObjectBuilder alloc] init];
-    [MaveSDK sharedInstance].remoteConfigurationBuilder = builder;
-    id remoteConfig = [[MAVERemoteConfiguration alloc] init];
-
-    id builderMock = OCMPartialMock(builder);
-    OCMStub([builderMock createObjectSynchronousWithTimeout:0]).andReturn(remoteConfig);
-
-    XCTAssertEqualObjects([[MaveSDK sharedInstance] remoteConfiguration],
-                          remoteConfig);
-}
-
 - (void)testSuggestedInvitesWithDelay {
     [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
     MAVEABPerson *p0 = [[MAVEABPerson alloc] init]; p0.recordID = 0; p0.hashedRecordID = 0;

--- a/MaveSDKTests/MaveSDKTests.m
+++ b/MaveSDKTests/MaveSDKTests.m
@@ -49,10 +49,9 @@
 
 - (void)testSetupSharedInstance {
     [MAVEABSyncManager resetSyncContactsOnceTokenForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
 
     MaveSDK *mave = [MaveSDK sharedInstance];
-    XCTAssertEqualObjects(mave.appId, @"foo123");
     XCTAssertNotNil(mave.displayOptions);
     XCTAssertEqualObjects(mave.defaultSMSMessageText, mave.remoteConfiguration.serverSMS.text);
     XCTAssertNotNil(mave.appDeviceID);
@@ -70,9 +69,9 @@
 
 
 - (void)testSharedInstanceIsShared {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MaveSDK *gk1 = [MaveSDK sharedInstance];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MaveSDK *gk2 = [MaveSDK sharedInstance];
     
     // Test pointer to same object
@@ -80,20 +79,20 @@
 }
 
 - (void)testResetSharedInstanceResetsUserDataButNotAppDeviceID {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     NSString *appDeviceID1 = [MaveSDK sharedInstance].appDeviceID;
     [MaveSDK sharedInstance].userData = [[MAVEUserData alloc] init];
     [MaveSDK sharedInstance].userData.userID = @"blah";
 
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     XCTAssertNil([MaveSDK sharedInstance].userData.userID);
     XCTAssertEqualObjects(appDeviceID1, [MaveSDK sharedInstance].appDeviceID);
 }
 
 // Test getting properties on the mave object
 - (void)testSuggestedInvitesWithDelay {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MAVEABPerson *p0 = [[MAVEABPerson alloc] init]; p0.recordID = 0; p0.hashedRecordID = 0;
     MAVEABPerson *p1 = [[MAVEABPerson alloc] init]; p1.recordID = 1; p1.hashedRecordID = 1;
     MAVEABPerson *p2 = [[MAVEABPerson alloc] init]; p2.recordID = 2; p2.hashedRecordID = 2;
@@ -128,7 +127,7 @@
 
 - (void)testGetReferringData {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"asd932k"];
+    [MaveSDK setupSharedInstance];
     XCTAssertFalse([MaveSDK sharedInstance].debug);
 
     MAVEReferringData *referringDataObj = [[MAVEReferringData alloc] init];
@@ -151,7 +150,7 @@
 
 - (void)testDebugGetReferringData {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"asd932k"];
+    [MaveSDK setupSharedInstance];
     MaveSDK *mave = [MaveSDK sharedInstance];
 
     mave.debug = YES;
@@ -300,7 +299,7 @@
 }
 
 - (void)testIdentifyUser {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MAVEUserData *userData = [[MAVEUserData alloc] initWithUserID:@"100" firstName:@"Dan" lastName:@"Foo" email:@"dan@example.com" phone:@"18085551234"];
     MaveSDK *mave = [MaveSDK sharedInstance];
     id mockAPIInterface = [OCMockObject mockForClass:[MAVEAPIInterface class]];
@@ -314,7 +313,7 @@
 }
 
 - (void)testIdentifyUserInvalidDoesntMakeNetworkRequest {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MAVEUserData *userData = [[MAVEUserData alloc] init];
     userData.userID = @"1";  // no first name
     id mockAPIInterface = OCMClassMock([MAVEAPIInterface class]);
@@ -346,7 +345,7 @@
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults removeObjectForKey:MAVEUserDefaultsKeyUserData];
 
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MAVEUserData *user = [[MAVEUserData alloc] init];
     user.firstName = @"aa234";
     [MaveSDK sharedInstance].userData = user;
@@ -361,7 +360,7 @@
 - (void)testUserDataGetsFromUserDefaultsIfNotSet {
     // Make sure state is reset
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     [MaveSDK sharedInstance].userData = nil;
     [defaults removeObjectForKey:MAVEUserDefaultsKeyUserData];
     XCTAssertNil([MaveSDK sharedInstance].userData);
@@ -385,27 +384,20 @@
     // to mean that the app has been launched before, if it's not on disk
     // then this is the first time the app has been launched
     [MAVEIDUtils clearStoredAppDeviceID];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     XCTAssertTrue([MaveSDK sharedInstance].isInitialAppLaunch);
 }
 
 - (void)testIsInitialLaunchNoOnSubsequentLaunches {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     XCTAssertNotNil([MaveSDK sharedInstance].appDeviceID);
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     XCTAssertFalse([MaveSDK sharedInstance].isInitialAppLaunch);
 }
 
-- (void)testIsSetupOKFailsWithNoApplicationID {
-    [MaveSDK setupSharedInstanceWithApplicationID:nil];
-    MaveSDK *mave = [MaveSDK sharedInstance];
-    [mave identifyAnonymousUser];
-    XCTAssertFalse([mave isSetupOK]);
-}
-
 - (void)testIsSetupOkSucceedsWithMinimumRequiredFields {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MaveSDK *mave = [MaveSDK sharedInstance];
     // didn't identify user, but it's ok
     XCTAssertTrue([mave isSetupOK]);
@@ -507,7 +499,7 @@
 }
 
 - (void)testTrackSignup {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MAVEUserData *userData = [[MAVEUserData alloc] init];
     // Verify the API request is sent
     id mockAPIInterface = [OCMockObject mockForClass:[MAVEAPIInterface class]];
@@ -525,7 +517,7 @@
 # pragma mark - Send SMS programatically Tests
 
 - (void)testSendSMSInviteMessageProgramaticallySuccessWithOptions {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foobar123"];
+    [MaveSDK setupSharedInstance];
 
     // setup the user to send sms from
     MAVEUserData *user = [[MAVEUserData alloc] init];
@@ -568,7 +560,7 @@
 }
 
 - (void)testSendSMSInviteMessageProgramaticallySuccessWithNoOptions {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foobar123"];
+    [MaveSDK setupSharedInstance];
 
     // setup the user to send sms from
     MAVEUserData *user = [[MAVEUserData alloc] init];
@@ -603,7 +595,7 @@
 }
 
 - (void)testSendSMSInviteMessageProgramaticallyFailsWithBadUserData {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foobar123"];
+    [MaveSDK setupSharedInstance];
 
     // setup the user to send sms from
     MAVEUserData *user = [[MAVEUserData alloc] init];
@@ -637,7 +629,7 @@
 }
 
 - (void)testSendSMSInviteMessageProgramaticallyFailsIfNetworkRequestFails {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foobar123"];
+    [MaveSDK setupSharedInstance];
 
     // setup the user to send sms from
     MAVEUserData *user = [[MAVEUserData alloc] init];
@@ -677,7 +669,7 @@
 }
 
 - (void)testSendSMSInviteMessageProgramaticallyWithNilErrorBlockIsOk {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foobar123"];
+    [MaveSDK setupSharedInstance];
     [MaveSDK sharedInstance].userData = nil;
     // no user data is set up
 
@@ -703,7 +695,7 @@
 }
 
 - (void)testSendSMSInviteMessageProgramaticallyFailsIfCustomReferringDataNotIsValidJSONObject {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foobar123"];
+    [MaveSDK setupSharedInstance];
     // setup the user to send sms from
     MAVEUserData *user = [[MAVEUserData alloc] init];
     user.userID = @"1"; user.firstName = @"Dan"; user.wrapInviteLink = YES;

--- a/MaveSDKTests/Models/MAVEABSyncManagerTests.m
+++ b/MaveSDKTests/Models/MAVEABSyncManagerTests.m
@@ -40,7 +40,7 @@
 - (void)setUp {
     [super setUp];
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
 }
 
 - (void)tearDown {

--- a/MaveSDKTests/Models/MAVEUserDataTests.m
+++ b/MaveSDKTests/Models/MAVEUserDataTests.m
@@ -27,7 +27,7 @@
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
 }
 
 - (void)tearDown {

--- a/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePageTests.m
+++ b/MaveSDKTests/Models/RemoteConfiguration/MAVERemoteConfigurationContactsInvitePageTests.m
@@ -40,7 +40,7 @@
     XCTAssertFalse([[template objectForKey:@"share_buttons_enabled"] boolValue]);
     XCTAssertFalse([[template objectForKey:@"suggested_invites_enabled"] boolValue]);
     XCTAssertFalse([[template objectForKey:@"select_all_enabled"] boolValue]);
-    XCTAssertEqualObjects([template objectForKey:@"sms_invite_send_method"], @"server_side");
+    XCTAssertEqualObjects([template objectForKey:@"sms_invite_send_method"], @"client_side_group");
     XCTAssertEqualObjects([template objectForKey:@"reusable_suggested_invite_cell_send_icon"], @"airplane");
 }
 
@@ -54,7 +54,7 @@
     XCTAssertFalse(obj.shareButtonsEnabled);
     XCTAssertFalse(obj.suggestedInvitesEnabled);
     XCTAssertFalse(obj.selectAllEnabled);
-    XCTAssertEqual(obj.smsInviteSendMethod, MAVESMSInviteSendMethodServerSide);
+    XCTAssertEqual(obj.smsInviteSendMethod, MAVESMSInviteSendMethodClientSideGroup);
     XCTAssertEqual(obj.reusableSuggestedInviteCellSendIcon, MAVEReusableSuggestedInviteCellSendIconAirplane);
 }
 

--- a/MaveSDKTests/Networking/MAVEAPIInterfaceTests.m
+++ b/MaveSDKTests/Networking/MAVEAPIInterfaceTests.m
@@ -31,7 +31,7 @@
 - (void)setUp {
     [super setUp];
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"12345"];
+    [MaveSDK setupSharedInstance];
     MAVEUserData *user = [[MAVEUserData alloc] initWithUserID:@"1"
                                                     firstName:@"foo"
                                                      lastName:@"bar"
@@ -50,7 +50,6 @@
 - (void)testInitAndCurrentUserProperties {
     XCTAssertEqualObjects(MAVEAPIBaseURL, @"test-api-mave-io/");
     XCTAssertEqualObjects(self.testAPIInterface.httpStack.baseURL, @"test-api-mave-io/v1.0");
-    XCTAssertEqualObjects(self.testAPIInterface.applicationID, [MaveSDK sharedInstance].appId);
     XCTAssertEqualObjects(self.testAPIInterface.applicationDeviceID, [MaveSDK sharedInstance].appDeviceID);
     XCTAssertEqualObjects(self.testAPIInterface.userData, [MaveSDK sharedInstance].userData);
 }
@@ -648,8 +647,6 @@
     [self.testAPIInterface addCustomUserHeadersToRequest:req];
     NSDictionary *headers = req.allHTTPHeaderFields;
     XCTAssertEqual([headers count], 6);
-    XCTAssertEqualObjects([headers objectForKey:@"X-Application-Id"],
-                          [MaveSDK sharedInstance].appId);
     XCTAssertEqualObjects([headers objectForKey:@"X-App-Device-Id"],
                           [MaveSDK sharedInstance].appDeviceID);
     CGSize screenSize = [[UIScreen mainScreen] bounds].size;

--- a/MaveSDKTests/Networking/MAVEHTTPStackTests.m
+++ b/MaveSDKTests/Networking/MAVEHTTPStackTests.m
@@ -187,46 +187,6 @@ typedef void (^MAVENSURLSessionCallback)(NSData *data, NSURLResponse *response, 
     }];
 }
 
-- (void)testSendPreparedRequest {
-    // Don't run this test on iOS7. The NSURLSession object can't be mocked on ios7, but
-    // it can be mocked on ios 8+
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] < 8.0) {
-        return;
-    }
-    NSURLRequest *req = [[NSURLRequest alloc] init];
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] init];
-    NSError *responseError = [[NSError alloc] init];
-    NSDictionary *responseDataAsDict = @{@"blah": @1};
-    NSData *responseData = [NSJSONSerialization dataWithJSONObject:responseDataAsDict
-                                                           options:0
-                                                             error:nil];
-    
-    // Mock session data task method to call the callback
-    id taskMock = OCMClassMock([NSURLSessionTask class]);
-    id sessionMock = OCMClassMock([NSURLSession class]);
-    self.testHTTPStack.session = sessionMock;
-    OCMExpect([sessionMock dataTaskWithRequest:req
-                             completionHandler:[OCMArg checkWithBlock:^BOOL(id obj) {
-        MAVENSURLSessionCallback cb = (MAVENSURLSessionCallback)obj;
-        cb(responseData, response, responseError);
-        return YES;
-    }]]).andReturn(taskMock);
-    
-    // Mock handle http method to ensure it's called
-    id httpStackMock = OCMPartialMock(self.testHTTPStack);
-    OCMExpect([httpStackMock handleJSONResponseWithData:responseData
-                                               response:response
-                                                  error:responseError
-                                        completionBlock:[OCMArg any]]);
-    
-    [self.testHTTPStack sendPreparedRequest:req
-                            completionBlock:^(NSError *error, NSDictionary *responseData) {}];
-    
-    OCMVerify([taskMock resume]);
-    OCMVerifyAll(sessionMock);
-    OCMVerifyAll(httpStackMock);
-}
-
 
 //
 // Tests for errors in building Request

--- a/MaveSDKTests/Utils/MAVEClientPropertyUtilsTests.m
+++ b/MaveSDKTests/Utils/MAVEClientPropertyUtilsTests.m
@@ -151,24 +151,11 @@
     XCTAssertEqualObjects([MAVEClientPropertyUtils urlSafeBase64EncodeAndStripData:nil], @"");
 }
 
-- (void)testUrlSafeBase64EncodeAppIDWhenBigInteger {
-    [MaveSDK sharedInstance].appId = @"202834210204166";
+- (void)testUrlSafeBase64EncodeAppID {
     XCTAssertEqualObjects([MAVEClientPropertyUtils urlSafeBase64ApplicationID],
-                          @"AAC4egUMKgY");
-
-    [MaveSDK sharedInstance].appId = @"0";
-    XCTAssertEqualObjects([MAVEClientPropertyUtils urlSafeBase64ApplicationID],
-                          @"AAAAAAAAAAA");
+                          @"PE5PIEFwcCBJRD4");
 }
 
-- (void)testUrlSafeBase64EncodeAppIDWhenString {
-    [MaveSDK sharedInstance].appId = @"10afdkjl3";
-    XCTAssertEqualObjects([MAVEClientPropertyUtils urlSafeBase64ApplicationID],
-                          @"MTBhZmRramwz");
-    [MaveSDK sharedInstance].appId = @"";
-    XCTAssertEqualObjects([MAVEClientPropertyUtils urlSafeBase64ApplicationID],
-                          @"");
-}
 
 
 ///

--- a/MaveSDKTests/Utils/MAVEClientPropertyUtilsTests.m
+++ b/MaveSDKTests/Utils/MAVEClientPropertyUtilsTests.m
@@ -47,10 +47,7 @@
 - (void)testEncodedContextProperties {
     [MaveSDK sharedInstance].inviteContext = @"foobartestcontext";
     XCTAssertNotNil([MaveSDK sharedInstance].userData.userID);
-    MAVERemoteConfiguration *remoteConfig = [[MAVERemoteConfiguration alloc] initWithDictionary:[MAVERemoteConfiguration defaultJSONData]];
-    id builderMock = OCMClassMock([MAVERemoteObjectBuilder class]);
-    OCMExpect([builderMock object]).andReturn(remoteConfig);
-    [MaveSDK sharedInstance].remoteConfigurationBuilder = builderMock;
+    [MaveSDK sharedInstance].remoteConfiguration = [[MAVERemoteConfiguration alloc] initWithDictionary:[MAVERemoteConfiguration defaultJSONData]];
 
     NSString *base64Properties = [MAVEClientPropertyUtils encodedContextProperties];
     NSDictionary *properties = [MAVEClientPropertyUtils base64DecodeJSONString:base64Properties];
@@ -67,7 +64,6 @@
     XCTAssertEqualObjects([properties objectForKey:@"facebook_share_template_id"], @"0");
     XCTAssertEqualObjects([properties objectForKey:@"twitter_share_template_id"], @"0");
     XCTAssertEqualObjects([properties objectForKey:@"clipboard_share_template_id"], @"0");
-    OCMVerifyAll(builderMock);
 }
 
 - (void)testEncodedContextPropertiesNull {
@@ -75,10 +71,7 @@
     MAVERemoteConfiguration *remoteConfig = [[MAVERemoteConfiguration alloc] init];
     remoteConfig.contactsInvitePage = [[MAVERemoteConfigurationContactsInvitePage alloc] init];
     remoteConfig.contactsInvitePage.templateID = nil;
-
-    id builderMock = OCMClassMock([MAVERemoteObjectBuilder class]);
-    OCMExpect([builderMock object]).andReturn(remoteConfig);
-    [MaveSDK sharedInstance].remoteConfigurationBuilder = builderMock;
+    [MaveSDK sharedInstance].remoteConfiguration = remoteConfig;
 
     NSString *base64Properties = [MAVEClientPropertyUtils encodedContextProperties];
     NSDictionary *properties = [MAVEClientPropertyUtils base64DecodeJSONString:base64Properties];

--- a/MaveSDKTests/Views/ContactsInvitePageV2/MAVEContactsInvitePageV2TableViewCellTests.m
+++ b/MaveSDKTests/Views/ContactsInvitePageV2/MAVEContactsInvitePageV2TableViewCellTests.m
@@ -59,7 +59,7 @@
 
 - (void)testHeightCellWillHave {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
 
     // hard code the default height
     CGFloat height = [MAVEContactsInvitePageV2TableViewCell heightCellWithHave];

--- a/MaveSDKTests/Views/MAVEABTableViewTests.m
+++ b/MaveSDKTests/Views/MAVEABTableViewTests.m
@@ -24,7 +24,7 @@
 - (void)setUp {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     [MaveSDK sharedInstance].displayOptions = [MAVEDisplayOptionsFactory generateDisplayOptions];
 }
 

--- a/MaveSDKTests/Views/MAVECustomSharePageViewTests.m
+++ b/MaveSDKTests/Views/MAVECustomSharePageViewTests.m
@@ -23,7 +23,7 @@
 - (void)setUp {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     [MaveSDK sharedInstance].displayOptions = [MAVEDisplayOptionsFactory generateDisplayOptions];
 }
 

--- a/MaveSDKTests/Views/MAVEInviteMessageViewTests.m
+++ b/MaveSDKTests/Views/MAVEInviteMessageViewTests.m
@@ -23,7 +23,7 @@
 
 - (void)setUp {
     [super setUp];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     [MaveSDK sharedInstance].displayOptions = [MAVEDisplayOptionsFactory generateDisplayOptions];
 }
 

--- a/MaveSDKTests/Views/MAVEInvitePageBottomActionSendButtonOnlyViewTests.m
+++ b/MaveSDKTests/Views/MAVEInvitePageBottomActionSendButtonOnlyViewTests.m
@@ -20,7 +20,7 @@
 
 - (void)setUp {
     [super setUp];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     [MaveSDK sharedInstance].displayOptions = [MAVEDisplayOptionsFactory generateDisplayOptions];
 }
 

--- a/MaveSDKTests/Views/MAVEInviteTableSectionHeaderViewTests.m
+++ b/MaveSDKTests/Views/MAVEInviteTableSectionHeaderViewTests.m
@@ -21,7 +21,7 @@
 - (void)setUp {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     [MaveSDK sharedInstance].displayOptions = [MAVEDisplayOptionsFactory generateDisplayOptions];
 }
 

--- a/MaveSDKTests/Views/MAVESearchBarTests.m
+++ b/MaveSDKTests/Views/MAVESearchBarTests.m
@@ -20,7 +20,7 @@
 
 - (void)setUp {
     [super setUp];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     [MaveSDK sharedInstance].displayOptions = [MAVEDisplayOptionsFactory generateDisplayOptions];
 }
 

--- a/MaveSDKTests/Views/MAVEShareButtonsViewTests.m
+++ b/MaveSDKTests/Views/MAVEShareButtonsViewTests.m
@@ -112,7 +112,7 @@
 }
 
 - (void)testAfterShareActionsNoDismissAfterShare {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MAVEShareButtonsView *view = [[MAVEShareButtonsView alloc] init];
     view.dismissMaveTopLevelOnSuccessfulShare = YES;
 

--- a/MaveSDKTests/Views/SuggestedInviteReusableCell/MAVEInviteFriendsReusableOvalButtonTests.m
+++ b/MaveSDKTests/Views/SuggestedInviteReusableCell/MAVEInviteFriendsReusableOvalButtonTests.m
@@ -62,7 +62,7 @@
 }
 
 - (void)testPresentInvitePageModallyPresentsPageAndTriggersCallbackIfSet {
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     id maveMock = OCMPartialMock([MaveSDK sharedInstance]);
 
     MAVEInviteFriendsReusableOvalButton *button = [[MAVEInviteFriendsReusableOvalButton alloc] init];

--- a/MaveSDKTests/Views/SuggestedInviteReusableCell/MAVESuggestedInviteReusableCellDelegateTests.m
+++ b/MaveSDKTests/Views/SuggestedInviteReusableCell/MAVESuggestedInviteReusableCellDelegateTests.m
@@ -124,7 +124,7 @@
 
 - (void)testSendInviteToContact {
     [MaveSDK resetSharedInstanceForTesting];
-    [MaveSDK setupSharedInstanceWithApplicationID:@"foo123"];
+    [MaveSDK setupSharedInstance];
     MAVEUserData *user = [[MAVEUserData alloc] init];
     user.userID = @"1234";
     [MaveSDK sharedInstance].userData = user;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Unfortunately, Mave the service has shut down as of Dec 2015.
+Mave the service has shut down as of Dec 2015.
 
-This library is still functional as a stand-alone invite or share page, but the Mave-provided services such as as SMS invite delivery, the stats dashboard, and suggested invites are no longer available.
+This library is still functional as a stand-alone invite or share page, but the Mave-provided services such as SMS invite delivery, the stats dashboard, and suggested invites are no longer available.
 
 The code is now open-source under an MIT license, so feel free to use it as you please.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Unfortunately, Mave the service has shut down as of Dec 2015.
+
+This library is still functional as a stand-alone invite or share page, but the Mave-provided services such as as SMS invite delivery, the stats dashboard, and suggested invites are no longer available.
+
+The code is now open-source under an MIT license, so feel free to use it as you please.
+
 # Mave iOS SDK
 
 [![Build Status](https://travis-ci.org/mave/mave-ios-sdk.svg?branch=master)](https://travis-ci.org/mave/mave-ios-sdk)
@@ -9,8 +15,6 @@ You can see it in action (without any server-side interactions) in the included 
  - then open `MaveSDK.xcworkspace` in xcode and build the `DemoApp` Target.
 
 ## Quick Integration
-
-See full docs [here](http://mave.io/docs).
 
 The Mave SDK is available through CocoaPods. To install it, simply add the following line to your Podfile:
 
@@ -24,10 +28,8 @@ Then, initialize the SDK in `applicationDidFinishLaunchingWithOptions:`
 ```objc
 #import <MaveSDK.h>;
 
-#define MAVE_SDK_APPLICATION_ID @"YOUR_APPLICATION_ID"
-
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [MaveSDK setupSharedInstanceWithApplicationID:MAVE_SDK_APPLICATION_ID];
+    [MaveSDK setupSharedInstance];
 
     // The rest of your app's setup code
 }
@@ -38,10 +40,6 @@ Then, use the following code to present the page (e.g. in the action for clickin
 
 
 ```objc
-MAVEUserData *userData = [[MAVEUserData alloc] initWithUserID:@"1"
-                                                    firstName:@"Example"
-                                                     lastName:@"Person"];
-[[MaveSDK sharedInstance] identifyUser:userData];
 [[MaveSDK sharedInstance] presentInvitePageModallyWithBlock:^(UIViewController *inviteController) {
     // Code to present Mave's view controller from yours, e.g:
     // [self presentViewController:inviteController animated:YES completion:nil];
@@ -50,9 +48,6 @@ MAVEUserData *userData = [[MAVEUserData alloc] initWithUserID:@"1"
     // is dismissed (sent invites or cancelled), e.g:
     // [controller dismissViewControllerAnimated:YES completion:nil];
 } inviteContext:@"default"];
-    // Passing an inviteContext allows you to track where a user came
-    // from to get to the invite page. (e.g. "drawer menu", "profile")
-    // It's used for analytics, not functionality.
 ```
 
 
@@ -64,4 +59,4 @@ info@mave.io
 
 ## License
 
-This SDK is released under a proprietary license, to use it in your released application you need to be using the Mave platform (sign up for our beta at [mave.io/beta/signup](http://app.mave.io/beta/signup)). See the LICENSE file.
+MIT. See the LICENSE file.


### PR DESCRIPTION
Removes the calls to Mave backend servers, take out the application id, and changes license to MIT
